### PR TITLE
Update Morse.hpp

### DIFF
--- a/src/nonbonded/Morse.hpp
+++ b/src/nonbonded/Morse.hpp
@@ -64,7 +64,7 @@ namespace OpenMD {
   public:    
     Morse();
     void setForceField(ForceField *ff) {forceField_ = ff;};
-    void setSimulatedAtomTypes(set<AtomType*> &simtypes) {simTypes_ = simtypes;};
+    void setSimulatedAtomTypes(set<AtomType*> &simtypes) {simTypes_ = simtypes; initialize();};
     void addExplicitInteraction(AtomType* atype1, AtomType* atype2, RealType De, RealType Re, RealType beta, MorseType mt);
     virtual void calcForce(InteractionData &idat);
     virtual string getName() {return name_;}


### PR DESCRIPTION
A simulation with EAM and Morse (specifically RepulsiveMorse) interactions would instantly fail. This was tracked down to a missing initialize() in the Morse.hpp file. It is possible that additional nonbonded files will need this same change.