### PR TITLE
Direction atom types / GB adjustments and fix build error

### DIFF
--- a/src/applications/staticProps/P2OrderParameter.cpp
+++ b/src/applications/staticProps/P2OrderParameter.cpp
@@ -120,7 +120,8 @@ namespace OpenMD {
         for (sd1 = seleMan1_.beginSelected(ii); sd1 != NULL; 
              sd1 = seleMan1_.nextSelected(ii)) {
           if (sd1->isDirectional()) {
-            Vector3d vec = sd1->getA().getColumn(2);
+            Vector3d vec = sd1->getA().getRow(2);
+            
             vec.normalize();
             orderTensor += outProduct(vec, vec);
             vecCount++;

--- a/src/nonbonded/GB.cpp
+++ b/src/nonbonded/GB.cpp
@@ -210,8 +210,15 @@ namespace OpenMD {
       
       //  Cleaver paper uses sqrt of squares to get sigma0 for
       //  mixed interactions.
+      ForceFieldOptions& fopts = forceField_->getForceFieldOptions();
+      string DistanceMix = fopts.getDistanceMixingRule();
+      toUpper(DistanceMix);
+
+      if (DistanceMix == "ARITHMETIC") 
+        mixer1.sigma0 = 0.5* (d1 + d2);
+      else 
+        mixer1.sigma0 = sqrt(d1*d1 + d2*d2);
       
-      mixer1.sigma0 = sqrt(d1*d1 + d2*d2);
       mixer1.xa2 = (l1*l1 - d1*d1)/(l1*l1 + d2*d2);
       mixer1.xai2 = (l2*l2 - d2*d2)/(l2*l2 + d1*d1);
       mixer1.x2 = (l1*l1 - d1*d1) * (l2*l2 - d2*d2) /
@@ -363,7 +370,6 @@ namespace OpenMD {
     *(idat.t1) += (dUda * rxu1 - dUdg * uxu) * *(idat.sw);
     *(idat.t2) += (dUdb * rxu2 + dUdg * uxu) * *(idat.sw);
     *(idat.vpair) += U;
-
     return;
 
   }

--- a/src/selection/HullFinder.cpp
+++ b/src/selection/HullFinder.cpp
@@ -129,7 +129,9 @@ namespace OpenMD {
   }
 
   HullFinder::~HullFinder() {
+#ifdef HAVE_QHULL
     delete surfaceMesh_;
+#endif
   }
 
   SelectionSet HullFinder::findHull() {


### PR DESCRIPTION
Hi, 

I've issued this pull request to address a few issues:

1. OpenMD does not build without QHULL due to an unguarded destructor on `surfaceMesh_` in HullFinder.cpp. I simply added guards. 

2. Added arithmetic mixing option to GB since the Cleaver formulation does not behave as expected for non dissimilar species. 

3. The P2 order parameter calculator for StaticProps used the column vector from the rotation matrix while the GB potential used the row vector for it's director. I adjusted StaticProps to be consistent with GB. Otherwise it may not calculate the correct OP. I've also attached images below illustrating this behavior for a Gay-Berne system.

![original](https://cloud.githubusercontent.com/assets/7806885/9069703/cc96fb3a-3ab8-11e5-8d75-c9a2d20c568a.png)

![adjusted](https://cloud.githubusercontent.com/assets/7806885/9069717/dc583912-3ab8-11e5-9060-e29ebef95b49.png)



Thanks! 
Hythem 