### PR TITLE
cppcheck: fix some reports

### DIFF
--- a/src/antlr/ASTFactory.cpp
+++ b/src/antlr/ASTFactory.cpp
@@ -61,7 +61,7 @@ ASTFactory::~ASTFactory()
 	{
 		if( *i != &default_factory_descriptor )
 			delete *i;
-		i++;
+		++i;
 	}
 }
 
@@ -126,7 +126,7 @@ RefAST ASTFactory::create(const ANTLR_USE_NAMESPACE(std)string& type_name, ANTLR
 			t->initialize(infile);
 			return t;
 		}
-		fact++;
+		++fact;
 	}
 
 	string error = "ASTFactory::create: Unknown AST type '" + type_name + "'";

--- a/src/applications/dynamicProps/MultipassCorrFunc.cpp
+++ b/src/applications/dynamicProps/MultipassCorrFunc.cpp
@@ -268,11 +268,11 @@ namespace OpenMD {
       // the selections until we have the same object to
       // correlate.
 
-      while ( *i1 < *i2 && i1 != s1.end()) {
+      while ( i1 != s1.end() && *i1 < *i2 ) {
         ++i1;
       }
       
-      while ( *i2 < *i1 && i2 != s2.end() ) {
+      while ( i2 != s2.end() && *i2 < *i1 ) {
         ++i2;
       }
           


### PR DESCRIPTION
[src/antlr/ASTFactory.cpp:64]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/antlr/ASTFactory.cpp:129]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/applications/dynamicProps/MultipassCorrFunc.cpp:271]: (warning) Possible dereference of an invalid iterator: i1
[src/applications/dynamicProps/MultipassCorrFunc.cpp:275]: (warning) Possible dereference of an invalid iterator: i2