### PR TITLE
ForceModifiers to replace ForceManagers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
   #     run: cmake --build . --target install
 
   ubuntu-builds:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,51 +23,51 @@ jobs:
   #     run: cmake --build . --target install
 
   ubuntu-builds:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Dependencies
-      run: |
-        sudo apt-get install libfftw3-3 libfftw3-dev
-        sudo apt-get install openbabel libopenbabel-dev
-        sudo apt-get install openmpi-bin libopenmpi-dev
-        sudo apt-get install python3-numpy python3-scipy
-        sudo apt-get install qhull-bin libqhull-dev
-        sudo apt-get install minizip zlib1g-dev
+      - name: Dependencies
+        run: |
+          sudo apt-get install libfftw3-3 libfftw3-dev
+          sudo apt-get install openbabel libopenbabel-dev
+          sudo apt-get install openmpi-bin libopenmpi-dev
+          sudo apt-get install python3-numpy python3-scipy
+          sudo apt-get install qhull-bin libqhull-dev
+          sudo apt-get install minizip zlib1g-dev
 
-    - name: Configure
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      - name: Configure
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
-    - name: Build
-      run: make -j 4
+      - name: Build
+        run: make -j 4
 
-    - name: Install
-      run: sudo make install
+      - name: Install
+        run: sudo make install
 
   macos-builds:
     runs-on: macos-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Dependencies
-      run: |
-        brew install fftw
-        brew install open-babel
-        brew install open-mpi
-        brew install numpy scipy
-        brew install qhull
-        brew install zlib
+      - name: Dependencies
+        run: |
+          brew install fftw
+          brew install open-babel
+          brew install open-mpi
+          brew install numpy scipy
+          brew install qhull
+          brew install zlib
 
-    - name: Configure
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      - name: Configure
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
-    - name: Build
-      run: make -j 4
+      - name: Build
+        run: make -j 4
 
-    - name: Install
-      run: sudo make install
+      - name: Install
+        run: sudo make install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,7 +405,7 @@ src/flucq/FluctuatingChargeNVT.cpp
 src/integrators/Integrator.cpp
 src/integrators/IntegratorFactory.cpp
 src/integrators/LangevinDynamics.cpp
-src/integrators/LDForceManager.cpp
+src/integrators/LDForceModifier.cpp
 src/integrators/NgammaT.cpp
 src/integrators/NPA.cpp
 src/integrators/NPAT.cpp
@@ -576,14 +576,14 @@ src/brains/SimCreator.cpp
 src/brains/SimInfo.cpp
 src/brains/Thermo.cpp
 src/brains/Velocitizer.cpp
-src/constraints/ZconstraintForceManager.cpp
+src/constraints/ZconstraintForceModifier.cpp
 src/constraints/Rattle.cpp
 src/constraints/Shake.cpp
 src/flucq/FluctuatingChargeConstraints.cpp
 src/flucq/FluctuatingChargeObjectiveFunction.cpp
 src/flucq/FluctuatingChargeForces.cpp
 src/flucq/FluctuatingChargePropagator.cpp
-src/integrators/LangevinHullForceManager.cpp
+src/integrators/LangevinHullForceModifier.cpp
 src/integrators/LangevinPiston.cpp
 src/rnemd/NIVS.cpp
 src/rnemd/RNEMD.cpp
@@ -604,8 +604,8 @@ src/parallel/ForceMatrixDecomposition.cpp
 src/perturbations/UniformField.cpp
 src/perturbations/MagneticField.cpp
 src/perturbations/UniformGradient.cpp
-src/restraints/RestraintForceManager.cpp
-src/restraints/ThermoIntegrationForceManager.cpp
+src/restraints/RestraintForceModifier.cpp
+src/restraints/ThermoIntegrationForceModifier.cpp
 src/selection/DistanceFinder.cpp
 src/selection/SelectionManager.cpp
 src/selection/SelectionSet.cpp
@@ -627,7 +627,7 @@ src/integrators/LangevinHullDynamics.cpp
 src/math/Triangle.cpp
 )
 set(QHULL_PARALLEL_SOURCE
-src/integrators/LangevinHullForceManager.cpp
+src/integrators/LangevinHullForceModifier.cpp
 src/math/ConvexHull.cpp
 src/math/AlphaHull.cpp
 )
@@ -715,7 +715,6 @@ src/applications/dynamicProps/AngularVelVelOutProdCorrFunc.cpp
 src/applications/dynamicProps/WCorrFunc.cpp
 src/applications/dynamicProps/BondCorrFunc.cpp
 src/applications/dynamicProps/DynamicPropsCmd.cpp
-
 )
 
 set (HYDROSOURCE
@@ -797,7 +796,6 @@ src/applications/staticProps/PositionZ.cpp
 src/applications/staticProps/DipoleOrientation.cpp
 src/applications/staticProps/ChargeDensityZ.cpp
 src/applications/staticProps/OrderParameterProbZ.cpp
-
 )
 
 set (NANOPARTICLEBUILDERSOURCE
@@ -883,10 +881,10 @@ add_executable(elasticConstants ${ELASTICCONSTANTSSOURCE} ${GETOPT_SOURCE})
 target_link_libraries(elasticConstants openmd_single openmd_core openmd_single openmd_core openmd_single)
 
 if (USE_OPENBABEL)
-set (ATOM2OMDSOURCE
-src/applications/atom2omd/atom2omd.cpp
-src/applications/atom2omd/openmdformat.cpp
-)
+  set (ATOM2OMDSOURCE
+  src/applications/atom2omd/atom2omd.cpp
+  src/applications/atom2omd/openmdformat.cpp
+  )
   add_executable(atom2omd ${ATOM2OMDSOURCE} ${GETOPT_SOURCE})
   target_link_libraries(atom2omd openmd_single openmd_core openmd_single openmd_core ${OPENBABEL_LIBRARIES})
   INSTALL(TARGETS atom2omd RUNTIME DESTINATION bin

--- a/samples/thermoIntegration/solid/ssde.omd
+++ b/samples/thermoIntegration/solid/ssde.omd
@@ -11,12 +11,12 @@ component{
 restraint{
   restraintType = "object";
   objectSelection = "select SSD_E";
-  displacementSpringConstant = 4.3;
-  twistSpringConstant = 750;   
+  displacementSpringConstant = 4.29;
+  twistSpringConstant = 17.75;   
   restrainedTwistAngle = 0.0;
-  swingXSpringConstant = 700;
+  swingXSpringConstant = 13.88;
   restrainedSwingXAngle = 0.0;
-  swingYSpringConstant = 700;
+  swingYSpringConstant = 13.88;
   restrainedSwingYAngle = 0.0;
   print = "false";
 }
@@ -24,7 +24,7 @@ restraint{
 useRestraints = "true";
 Restraint_file = "idealCrystal.in";
 
-ensemble = NVT;
+ensemble = NVE;
 forceField = "DUFF";
 electrostaticSummationMethod = "shifted_force";
 dielectric = 80.0;
@@ -36,19 +36,19 @@ targetPressure = 1.0;
 tauThermostat = 1e3;
 tauBarostat = 1e4;
 
-dt = 2.0;
+dt = 1.0;
 runTime = 1e3;
 useInitialTime = "false";
 useInitialExtendedSystemState = "false";
 
 useThermodynamicIntegration = "true";
-thermodynamicIntegrationLambda = 0.0;
+thermodynamicIntegrationLambda = 0.5;
 thermodynamicIntegrationK = 1.0;
 
 //tempSet = "true";
 //thermalTime = 10;
 sampleTime = 100;
-statusTime = 10;
+statusTime = 1;
   </MetaData>
   <Snapshot>
     <FrameData>

--- a/src/applications/openmd/openmd.cpp
+++ b/src/applications/openmd/openmd.cpp
@@ -43,18 +43,17 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
-#ifdef IS_MPI
-#include <mpi.h>
-#endif
-
 #include <fstream>
 #include <iostream>
 #include <locale>
 
+#ifdef IS_MPI
+#include <mpi.h>
+#endif
+
 #include "brains/Register.hpp"
 #include "brains/SimCreator.hpp"
 #include "brains/SimInfo.hpp"
-#include "constraints/ZconstraintForceManager.hpp"
 #include "integrators/Integrator.hpp"
 #include "integrators/IntegratorFactory.hpp"
 #include "optimization/Constraint.hpp"
@@ -62,8 +61,6 @@
 #include "optimization/OptimizationFactory.hpp"
 #include "optimization/PotentialEnergyObjectiveFunction.hpp"
 #include "optimization/Problem.hpp"
-#include "restraints/RestraintForceManager.hpp"
-#include "restraints/ThermoIntegrationForceManager.hpp"
 #include "utils/CaseConversion.hpp"
 #include "utils/Revision.hpp"
 #include "utils/simError.h"
@@ -234,7 +231,6 @@ int main(int argc, char* argv[]) {
     delete myMinimizer;
   } else if (simParams->haveEnsemble()) {
     // create Integrator
-
     Integrator* myIntegrator =
         IntegratorFactory::getInstance().createIntegrator(
             toUpperCopy(simParams->getEnsemble()), info);
@@ -245,27 +241,6 @@ int main(int argc, char* argv[]) {
               simParams->getEnsemble().c_str());
       painCave.isFatal = 1;
       simError();
-    }
-
-    // Thermodynamic Integration Method
-    // set the force manager for thermodynamic integration if specified
-    if (simParams->getUseThermodynamicIntegration()) {
-      ForceManager* fman = new ThermoIntegrationForceManager(info);
-      myIntegrator->setForceManager(fman);
-    }
-
-    // Restraints
-    if (simParams->getUseRestraints() &&
-        !simParams->getUseThermodynamicIntegration()) {
-      ForceManager* fman = new RestraintForceManager(info);
-      myIntegrator->setForceManager(fman);
-    }
-
-    // Zconstraint-Method
-    if (simParams->getNZconsStamps() > 0) {
-      info->setNZconstraint(simParams->getNZconsStamps());
-      ForceManager* fman = new ZconstraintForceManager(info);
-      myIntegrator->setForceManager(fman);
     }
 
     myIntegrator->integrate();

--- a/src/applications/utilities/waterReplacer
+++ b/src/applications/utilities/waterReplacer
@@ -41,7 +41,6 @@ WaterQuats = []
 indices = []
 Hmat = []
 BoxInv = []
-H = []
 Eliminate = []
 
 #Hmat = zeros([3,3],Float)
@@ -77,22 +76,17 @@ def findWaters():
     print("finding water molecules")
     # simpler since we only have to find H atoms within a few
     # angstroms of each water:
-
+    H = []
     hCovRad = 0.32
     oCovRad = 0.73
     covTol = 0.45
     OHbond = hCovRad + oCovRad + covTol
     Hmass = 1.0079
     Omass = 15.9994
-    # initialize H array to an error condition
-    H.append(-1)
-    H.append(-1)
     
     for i in range(len(indices)):
         if (atypes[i] == "O"):
-            nH = 0
-            H[0] = -1
-            H[1] = -1
+            H.clear()
             COM = [0.0, 0.0, 0.0]
             opos = positions[i]
             for j in range(len(indices)):
@@ -103,14 +97,12 @@ def findWaters():
                     dz = opos[2] - hpos[2]
                     dist = math.sqrt(dx*dx + dy*dy + dz*dz)
                     if (dist < OHbond):
-                        if (nH >= 2):
+                        if (len(H) >= 2):
                             print("oxygen %d had too many hydrogens" % (i))
-                            sys.exit(1)
-                        H[nH] = j
-                        nH = nH + 1
-            if (nH != 2):
-                print("oxygen %d had %d hydrogens, skipping" % (i, nH))
-            if (nH == 2):
+                        H.append(j)
+            if (len(H) != 2):
+                print("oxygen %d had %d hydrogens, skipping" % (i, len(H)))
+            if (len(H) == 2):
                 Xcom = Omass * opos[0] + Hmass*(positions[H[0]][0] + positions[H[1]][0])
                 Ycom = Omass * opos[1] + Hmass*(positions[H[0]][1] + positions[H[1]][1])
                 Zcom = Omass * opos[2] + Hmass*(positions[H[0]][2] + positions[H[1]][2])

--- a/src/brains/ForceField.cpp
+++ b/src/brains/ForceField.cpp
@@ -787,5 +787,4 @@ namespace OpenMD {
     }
     return ffStream;
   }
-
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/brains/ForceField.hpp
+++ b/src/brains/ForceField.hpp
@@ -184,5 +184,5 @@ namespace OpenMD {
     std::string wildCardAtomTypeName_;
     std::string forceFieldFileName_;
   };
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif

--- a/src/brains/ForceManager.hpp
+++ b/src/brains/ForceManager.hpp
@@ -53,13 +53,13 @@
 #ifndef BRAINS_FORCEMANAGER_HPP
 #define BRAINS_FORCEMANAGER_HPP
 
+#include "brains/ForceModifier.hpp"
 #include "brains/SimInfo.hpp"
 #include "brains/Thermo.hpp"
 #include "nonbonded/Cutoffs.hpp"
 #include "nonbonded/InteractionManager.hpp"
 #include "nonbonded/SwitchingFunction.hpp"
 #include "parallel/ForceDecomposition.hpp"
-#include "perturbations/Perturbation.hpp"
 #include "primitives/Molecule.hpp"
 #include "selection/SelectionEvaluator.hpp"
 #include "selection/SelectionManager.hpp"
@@ -124,28 +124,27 @@ namespace OpenMD {
     CutoffMethod
         cutoffMethod_; /**< Cutoff Method for most non-bonded interactions */
 
-    set<AtomType*> atomTypes_;
-    vector<pair<AtomType*, AtomType*>> interactions_;
-    map<Bend*, BendDataSet> bendDataSets;
-    map<Torsion*, TorsionDataSet> torsionDataSets;
-    map<Inversion*, InversionDataSet> inversionDataSets;
-    // vector<pair<int, int> > neighborList_;
-    vector<int> neighborList_;
-    vector<int> point_;
+    std::set<AtomType*> atomTypes_;
+    std::vector<pair<AtomType*, AtomType*>> interactions_;
+    std::map<Bend*, BendDataSet> bendDataSets;
+    std::map<Torsion*, TorsionDataSet> torsionDataSets;
+    std::map<Inversion*, InversionDataSet> inversionDataSets;
+    std::vector<int> neighborList_;
+    std::vector<int> point_;
 
-    vector<RealType> vdwScale_;
-    vector<RealType> electrostaticScale_;
+    std::vector<RealType> vdwScale_;
+    std::vector<RealType> electrostaticScale_;
 
     Mat3x3d virialTensor;
 
-    vector<Perturbation*> perturbations_;
+    std::vector<ForceModifier*> forceModifiers_;
 
     bool doPotentialSelection_ {false};
-    string selectionScript_;
+    std::string selectionScript_;
     SelectionManager seleMan_;
     SelectionEvaluator evaluator_;
-    // And all of the variables and structures for long range interactions:
 
+    // And all of the variables and structures for long range interactions:
     InteractionData idat;
     SelfData sdat;
   };

--- a/src/brains/ForceModifier.hpp
+++ b/src/brains/ForceModifier.hpp
@@ -43,79 +43,24 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
-#ifndef CONSTRAINTS_ZCONSTRAINTFORCEMANAGER_HPP
-#define CONSTRAINTS_ZCONSTRAINTFORCEMANAGER_HPP
-#include <list>
-#include <string>
-#include <vector>
+#ifndef BRAINS_FORCEMODIFIER_HPP
+#define BRAINS_FORCEMODIFIER_HPP
 
-#include "brains/ForceManager.hpp"
-#include "constraints/ZconsStruct.hpp"
-#include "io/ZConsWriter.hpp"
+#include "brains/SimInfo.hpp"
+
 namespace OpenMD {
 
-  class ZconstraintForceManager : public ForceManager {
+  //! Abstract class for external ForceModifier classes
+  class ForceModifier {
   public:
-    ZconstraintForceManager(SimInfo* info);
-    ~ZconstraintForceManager();
+    virtual ~ForceModifier()    = default;
+    virtual void modifyForces() = 0;
 
-    virtual void calcForces();
+  protected:
+    ForceModifier(SimInfo* info) : info_ {info} {}
 
-    RealType getZConsTime() { return zconsTime_; }
-    std::string getZConsOutput() { return zconsOutput_; }
-
-    void update();
-    virtual void init();
-
-  private:
-    bool isZMol(Molecule* mol);
-    void thermalize(void);
-
-    void zeroVelocity();
-    void doZconstraintForce();
-    void doHarmonic();
-    bool checkZConsState();
-    void updateZPos();
-    void updateCantPos();
-    void calcTotalMassMovingZMols();
-    bool haveMovingZMols();
-    bool haveFixedZMols();
-    RealType getZTargetPos(int index);
-    RealType getZFOfFixedZMols(Molecule* mol, StuntDouble* sd,
-                               RealType totalForce);
-    RealType getZFOfMovingMols(Molecule* mol, RealType totalForce);
-    RealType getHFOfFixedZMols(Molecule* mol, StuntDouble* sd,
-                               RealType totalForce);
-    RealType getHFOfUnconsMols(Molecule* mol, RealType totalForce);
-
-    std::list<ZconstraintMol>
-        movingZMols_;                      /**<   moving zconstraint molecules*/
-    std::list<ZconstraintMol> fixedZMols_; /**< fixed zconstraint molecules*/
-    std::vector<Molecule*> unzconsMols_;   /**< free molecules*/
-
-    RealType zconsTime_;
-    std::string zconsOutput_;
-    RealType zconsTol_;
-    bool usingSMD_;
-    RealType zconsFixingTime_;
-    RealType zconsGap_;
-    bool usingZconsGap_;
-    RealType dt_;
-
-    const static int whichDirection = 2;
-
-    std::map<int, ZconstraintParam> allZMolIndices_;
-
-    Snapshot* currSnapshot_;
-    RealType currZconsTime_;
-
-    RealType totMassMovingZMols_;
-    RealType totMassUnconsMols_; /**< mass of unconstrained molecules
-                                     in the system (never changes) */
-
-    ZConsWriter* fzOut;
-    const RealType infiniteTime;
+    SimInfo* info_ {nullptr};
   };
-
 }  // namespace OpenMD
-#endif
+
+#endif  // BRAINS_FORCEMODIFIER_HPP

--- a/src/brains/PairList.hpp
+++ b/src/brains/PairList.hpp
@@ -102,6 +102,6 @@ namespace OpenMD {
     bool modified_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 
 #endif  // __PAIRLIST_H__

--- a/src/brains/Register.cpp
+++ b/src/brains/Register.cpp
@@ -113,9 +113,9 @@ namespace OpenMD {
         new IntegratorBuilder<LangevinHullDynamics>("LANGEVINHULL"));
     IntegratorFactory::getInstance().registerIntegrator(
         new IntegratorBuilder<LangevinHullDynamics>("SMIPD"));
+#endif
     IntegratorFactory::getInstance().registerIntegrator(
         new IntegratorBuilder<LangevinPiston>("LANGEVINPISTON"));
-#endif
   }
 
   void registerOptimizers() {

--- a/src/brains/SimCreator.cpp
+++ b/src/brains/SimCreator.cpp
@@ -50,14 +50,16 @@
  * @version 1.0
  */
 
-#ifdef IS_MPI
-#include "mpi.h"
-#endif
+#include "brains/SimCreator.hpp"
 
 #include <exception>
 #include <iostream>
 #include <sstream>
 #include <string>
+
+#ifdef IS_MPI
+#include <mpi.h>
+#endif
 
 #include "antlr/ANTLRException.hpp"
 #include "antlr/CharStreamException.hpp"
@@ -71,7 +73,6 @@
 #include "antlr/TokenStreamRecognitionException.hpp"
 #include "brains/ForceField.hpp"
 #include "brains/MoleculeCreator.hpp"
-#include "brains/SimCreator.hpp"
 #include "brains/SimSnapshotManager.hpp"
 #include "io/DumpReader.hpp"
 #include "mdParser/MDLexer.hpp"

--- a/src/brains/SimCreator.hpp
+++ b/src/brains/SimCreator.hpp
@@ -129,5 +129,5 @@ namespace OpenMD {
         mdFileName_;  // save the meta-data file name which may be used later
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // BRAINS_SIMCREATOR_HPP

--- a/src/brains/SimInfo.cpp
+++ b/src/brains/SimInfo.cpp
@@ -1049,5 +1049,4 @@ namespace OpenMD {
     nGlobalConstraints_     = nConstraints_;
 #endif
   }
-
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/brains/SimInfo.cpp
+++ b/src/brains/SimInfo.cpp
@@ -52,16 +52,16 @@
 
 #include "brains/SimInfo.hpp"
 
-#ifdef IS_MPI
-#include <mpi.h>
-#endif
-
 #include <algorithm>
 #include <cstdint>
 #include <map>
 #include <memory>
 #include <random>
 #include <set>
+
+#ifdef IS_MPI
+#include <mpi.h>
+#endif
 
 #include "brains/ForceField.hpp"
 #include "io/ForceFieldOptions.hpp"

--- a/src/brains/Snapshot.cpp
+++ b/src/brains/Snapshot.cpp
@@ -483,11 +483,15 @@ namespace OpenMD {
       frameData.potentialEnergy = this->getLongRangePotential();
       frameData.potentialEnergy += this->getShortRangePotential();
       frameData.potentialEnergy += this->getSelfPotential();
-      frameData.potentialEnergy += this->getRestraintPotential();
       frameData.potentialEnergy += this->getExcludedPotential();
       hasPotentialEnergy = true;
     }
     return frameData.potentialEnergy;
+  }
+
+  void Snapshot::setPotentialEnergy(const RealType pe) {
+    frameData.potentialEnergy = pe;
+    hasPotentialEnergy = true;
   }
 
   void Snapshot::setExcludedPotentials(potVec exPot) {

--- a/src/brains/Snapshot.cpp
+++ b/src/brains/Snapshot.cpp
@@ -491,7 +491,7 @@ namespace OpenMD {
 
   void Snapshot::setPotentialEnergy(const RealType pe) {
     frameData.potentialEnergy = pe;
-    hasPotentialEnergy = true;
+    hasPotentialEnergy        = true;
   }
 
   void Snapshot::setExcludedPotentials(potVec exPot) {

--- a/src/brains/Snapshot.cpp
+++ b/src/brains/Snapshot.cpp
@@ -520,13 +520,9 @@ namespace OpenMD {
     return frameData.restraintPotential;
   }
 
-  void Snapshot::setRawPotential(RealType rp) {
-    frameData.rawPotential = rp;
-  }
+  void Snapshot::setRawPotential(RealType rp) { frameData.rawPotential = rp; }
 
-  RealType Snapshot::getRawPotential() {
-    return frameData.rawPotential;
-  }
+  RealType Snapshot::getRawPotential() { return frameData.rawPotential; }
 
   void Snapshot::setSelectionPotentials(potVec selPot) {
     frameData.selectionPotentials = selPot;

--- a/src/brains/Snapshot.hpp
+++ b/src/brains/Snapshot.hpp
@@ -238,6 +238,7 @@ namespace OpenMD {
     potVec getSelectionPotentials();
 
     RealType getPotentialEnergy();
+    void setPotentialEnergy(const RealType pe);
     RealType getKineticEnergy();
     RealType getTranslationalKineticEnergy();
     RealType getRotationalKineticEnergy();

--- a/src/brains/Stats.cpp
+++ b/src/brains/Stats.cpp
@@ -454,12 +454,17 @@ namespace OpenMD {
     // if we're doing a thermodynamic integration, we'll want the raw
     // potential as well as the full potential:
 
-    if (simParams->getUseThermodynamicIntegration())
+    if (simParams->getUseThermodynamicIntegration()) {
       statsMask_.set(RAW_POTENTIAL);
+      statsMask_.set(RESTRAINT_POTENTIAL);
+    }
 
     // if we've got restraints turned on, we'll also want a report of the
     // total harmonic restraints
-    if (simParams->getUseRestraints()) { statsMask_.set(RESTRAINT_POTENTIAL); }
+    if (simParams->getUseRestraints()) {
+      statsMask_.set(RAW_POTENTIAL);
+      statsMask_.set(RESTRAINT_POTENTIAL);
+    }
 
     if (simParams->havePrintPressureTensor() &&
         simParams->getPrintPressureTensor()) {

--- a/src/brains/Thermo.cpp
+++ b/src/brains/Thermo.cpp
@@ -43,14 +43,15 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
-#ifdef IS_MPI
-#include <mpi.h>
-#endif  // is_mpi
+#include "brains/Thermo.hpp"
 
 #include <cmath>
 #include <iostream>
 
-#include "brains/Thermo.hpp"
+#ifdef IS_MPI
+#include <mpi.h>
+#endif
+
 #include "primitives/Molecule.hpp"
 #include "types/FixedChargeAdapter.hpp"
 #include "types/FluctuatingChargeAdapter.hpp"

--- a/src/brains/Thermo.hpp
+++ b/src/brains/Thermo.hpp
@@ -130,5 +130,5 @@ namespace OpenMD {
     SimInfo* info_ {nullptr};
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif

--- a/src/constraints/Rattle.cpp
+++ b/src/constraints/Rattle.cpp
@@ -47,11 +47,12 @@
 
 #include <cmath>
 
-#include "primitives/Molecule.hpp"
-#include "utils/simError.h"
 #ifdef IS_MPI
 #include <mpi.h>
 #endif
+
+#include "primitives/Molecule.hpp"
+#include "utils/simError.h"
 
 namespace OpenMD {
 

--- a/src/constraints/Shake.cpp
+++ b/src/constraints/Shake.cpp
@@ -45,11 +45,12 @@
 
 #include "constraints/Shake.hpp"
 
-#include "primitives/Molecule.hpp"
-#include "utils/simError.h"
 #ifdef IS_MPI
 #include <mpi.h>
 #endif
+
+#include "primitives/Molecule.hpp"
+#include "utils/simError.h"
 
 namespace OpenMD {
 

--- a/src/constraints/ZconsStruct.hpp
+++ b/src/constraints/ZconsStruct.hpp
@@ -45,7 +45,9 @@
 
 #ifndef CONSTRAINTS_ZCONSSTRUCT_HPP
 #define CONSTRAINTS_ZCONSSTRUCT_HPP
+
 #include "primitives/Molecule.hpp"
+
 namespace OpenMD {
 
   struct ZconstraintParam {
@@ -69,7 +71,6 @@ namespace OpenMD {
     RealType zpos;
     RealType zconsPos;
   };
-
 }  // namespace OpenMD
 
 #endif

--- a/src/flucq/FluctuatingChargeConstraints.cpp
+++ b/src/flucq/FluctuatingChargeConstraints.cpp
@@ -43,11 +43,12 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
+#include "FluctuatingChargeConstraints.hpp"
+
 #ifdef IS_MPI
 #include <mpi.h>
 #endif
 
-#include "FluctuatingChargeConstraints.hpp"
 #include "primitives/Molecule.hpp"
 
 namespace OpenMD {

--- a/src/flucq/FluctuatingChargeForces.cpp
+++ b/src/flucq/FluctuatingChargeForces.cpp
@@ -43,11 +43,12 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
+#include "flucq/FluctuatingChargeForces.hpp"
+
 #ifdef IS_MPI
 #include <mpi.h>
 #endif
 
-#include "flucq/FluctuatingChargeForces.hpp"
 #include "math/RealSymmetricTridiagonal.hpp"
 #include "types/FluctuatingChargeAdapter.hpp"
 

--- a/src/flucq/FluctuatingChargeObjectiveFunction.cpp
+++ b/src/flucq/FluctuatingChargeObjectiveFunction.cpp
@@ -44,8 +44,9 @@
  */
 
 #include "flucq/FluctuatingChargeObjectiveFunction.hpp"
+
 #ifdef IS_MPI
-#include "mpi.h"
+#include <mpi.h>
 #endif
 
 namespace OpenMD {

--- a/src/flucq/FluctuatingChargePropagator.cpp
+++ b/src/flucq/FluctuatingChargePropagator.cpp
@@ -45,16 +45,16 @@
 
 #include "flucq/FluctuatingChargePropagator.hpp"
 
+#ifdef IS_MPI
+#include <mpi.h>
+#endif
+
 #include "flucq/FluctuatingChargeObjectiveFunction.hpp"
 #include "optimization/Constraint.hpp"
 #include "optimization/EndCriteria.hpp"
 #include "optimization/OptimizationFactory.hpp"
 #include "optimization/Problem.hpp"
 #include "optimization/StatusFunction.hpp"
-
-#ifdef IS_MPI
-#include <mpi.h>
-#endif
 
 using namespace QuantLib;
 namespace OpenMD {

--- a/src/integrators/Integrator.cpp
+++ b/src/integrators/Integrator.cpp
@@ -112,10 +112,6 @@ namespace OpenMD {
       resetTime = simParams->getResetTime();
     }
 
-    // Create a default ForceManager: If the subclass wants to use
-    // a different ForceManager, use setForceManager
-    forceMan_ = new ForceManager(info);
-
     // check for the temperature set flag (velocity scaling)
     needVelocityScaling = false;
     if (simParams->haveTempSet()) {
@@ -160,6 +156,8 @@ namespace OpenMD {
       }
     }
 
+    if (forceMan_ == NULL) forceMan_ = new ForceManager(info);
+
     rotAlgo_ = new DLM();
     rattle_  = new Rattle(info);
 
@@ -184,6 +182,7 @@ namespace OpenMD {
         painCave.isFatal = 1;
       }
     }
+
     flucQ_->setForceManager(forceMan_);
   }
 
@@ -200,13 +199,6 @@ namespace OpenMD {
   void Integrator::updateSizes() {
     doUpdateSizes();
     flucQ_->updateSizes();
-  }
-
-  void Integrator::setForceManager(ForceManager* forceMan) {
-    if (forceMan_ != forceMan && forceMan_ != NULL) { delete forceMan_; }
-    forceMan_ = forceMan;
-    // forward this on:
-    if (flucQ_ != NULL) { flucQ_->setForceManager(forceMan_); }
   }
 
   void Integrator::setVelocitizer(std::unique_ptr<Velocitizer> velocitizer) {

--- a/src/integrators/Integrator.hpp
+++ b/src/integrators/Integrator.hpp
@@ -57,7 +57,6 @@
 #include "integrators/RotationAlgorithm.hpp"
 #include "io/DumpWriter.hpp"
 #include "io/StatWriter.hpp"
-#include "restraints/ThermoIntegrationForceManager.hpp"
 #include "rnemd/RNEMD.hpp"
 #include "utils/ProgressBar.hpp"
 
@@ -81,7 +80,6 @@ namespace OpenMD {
 
     void integrate();
     void updateSizes();
-    void setForceManager(ForceManager* forceMan);
     void setVelocitizer(std::unique_ptr<Velocitizer> velocitizer);
     void setFluctuatingChargePropagator(FluctuatingChargePropagator* prop);
     void setRotationAlgorithm(RotationAlgorithm* algo);

--- a/src/integrators/LDForceModifier.cpp
+++ b/src/integrators/LDForceModifier.cpp
@@ -67,7 +67,8 @@ namespace OpenMD {
       ForceModifier {info}, maxIterNum_ {4}, forceTolerance_ {1e-6},
       randNumGen_ {info->getRandomNumberGenerator()},
       simParams_ {info->getSimParams()} {
-    dt2_ = simParams_->getDt() * 0.5;
+    RealType dt = simParams_->getDt();
+    dt2_        = dt * 0.5;
 
     // Remove in favor of std::make_unique<> when we switch to C++14 and above
     veloMunge_ = Utils::make_unique<Velocitizer>(info_);
@@ -237,8 +238,7 @@ namespace OpenMD {
     }
 
     RealType stdDev =
-        std::sqrt(2.0 * Constants::kb * simParams_->getTargetTemp() /
-                  simParams_->getDt());
+        std::sqrt(2.0 * Constants::kb * simParams_->getTargetTemp() / dt);
 
     forceDistribution_ = std::normal_distribution<RealType>(0.0, stdDev);
   }

--- a/src/integrators/LDForceModifier.hpp
+++ b/src/integrators/LDForceModifier.hpp
@@ -43,8 +43,8 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
-#ifndef INTEGRATOR_LDFORCEMANAGER_HPP
-#define INTEGRATOR_LDFORCEMANAGER_HPP
+#ifndef INTEGRATOR_LDFORCEMODIFIER_HPP
+#define INTEGRATOR_LDFORCEMODIFIER_HPP
 
 #include <map>
 #include <memory>
@@ -52,7 +52,7 @@
 #include <string>
 #include <vector>
 
-#include "brains/ForceManager.hpp"
+#include "brains/ForceModifier.hpp"
 #include "brains/Velocitizer.hpp"
 #include "hydrodynamics/Shape.hpp"
 #include "primitives/Molecule.hpp"
@@ -72,34 +72,24 @@ namespace OpenMD {
   };
 
   /**
-   * @class LDForceManager
-   * Force manager for Lagevin Dynamics applying friction and random
+   * @class LDForceModifier
+   * Force modifier for Lagevin Dynamics applying friction and random
    * forces as well as torques.
    */
-  class LDForceManager : public ForceManager {
+  class LDForceModifier : public ForceModifier {
   public:
-    LDForceManager(SimInfo* info);
+    LDForceModifier(SimInfo* info);
 
+    void modifyForces() override;
     int getMaxIterationNumber() { return maxIterNum_; }
-
     void setMaxIterationNumber(int maxIter) { maxIterNum_ = maxIter; }
-
     RealType getForceTolerance() { return forceTolerance_; }
-
     void setForceTolerance(RealType tol) { forceTolerance_ = tol; }
-
-    RealType getDt2() { return dt2_; }
-
-    void setDt2(RealType dt2) { dt2_ = dt2; }
-
-  protected:
-    virtual void postCalculation();
 
   private:
     std::map<std::string, HydroProp*> parseFrictionFile(
         const std::string& filename);
     MomentData* getMomentData(StuntDouble* sd);
-
     void genRandomForceAndTorque(Vector3d& force, Vector3d& torque,
                                  unsigned int index);
 
@@ -121,8 +111,8 @@ namespace OpenMD {
     RealType langevinBufferRadius_;
     RealType frozenBufferRadius_;
     bool sphericalBoundaryConditions_;
-    Globals* simParams;
-    std::unique_ptr<Velocitizer> veloMunge {nullptr};
+    Globals* simParams_;
+    std::unique_ptr<Velocitizer> veloMunge_ {nullptr};
   };
 }  // namespace OpenMD
-#endif  // BRAINS_FORCEMANAGER_HPP
+#endif  // INTEGRATOR_LDFORCEMODIFIER_HPP

--- a/src/integrators/LangevinDynamics.cpp
+++ b/src/integrators/LangevinDynamics.cpp
@@ -164,4 +164,4 @@ namespace OpenMD {
 
   RealType LangevinDynamics::calcConservedQuantity() { return 0.0; }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/integrators/LangevinDynamics.cpp
+++ b/src/integrators/LangevinDynamics.cpp
@@ -52,19 +52,13 @@
 
 #include "integrators/LangevinDynamics.hpp"
 
-#include "integrators/LDForceManager.hpp"
 #include "primitives/Molecule.hpp"
 #include "utils/Constants.hpp"
+
 namespace OpenMD {
 
   LangevinDynamics::LangevinDynamics(SimInfo* info) :
-      VelocityVerletIntegrator(info) {
-    setForceManager(new LDForceManager(info));
-
-    // Langevin Dynamics Force Manager needs to know about the half-time step
-    // size to get convergence on the friction forces:
-    dynamic_cast<LDForceManager*>(forceMan_)->setDt2(dt2);
-  }
+      VelocityVerletIntegrator(info) {}
 
   void LangevinDynamics::moveA() {
     SimInfo::MoleculeIterator i;
@@ -163,5 +157,4 @@ namespace OpenMD {
   }
 
   RealType LangevinDynamics::calcConservedQuantity() { return 0.0; }
-
 }  // namespace OpenMD

--- a/src/integrators/LangevinHullDynamics.cpp
+++ b/src/integrators/LangevinHullDynamics.cpp
@@ -52,15 +52,13 @@
 
 #include "integrators/LangevinHullDynamics.hpp"
 
-#include "integrators/LangevinHullForceManager.hpp"
 #include "primitives/Molecule.hpp"
 #include "utils/Constants.hpp"
+
 namespace OpenMD {
 
   LangevinHullDynamics::LangevinHullDynamics(SimInfo* info) :
-      VelocityVerletIntegrator(info) {
-    setForceManager(new LangevinHullForceManager(info));
-  }
+      VelocityVerletIntegrator(info) {}
 
   void LangevinHullDynamics::moveA() {
     SimInfo::MoleculeIterator i;
@@ -159,5 +157,4 @@ namespace OpenMD {
   }
 
   RealType LangevinHullDynamics::calcConservedQuantity() { return 0.0; }
-
 }  // namespace OpenMD

--- a/src/integrators/LangevinHullDynamics.cpp
+++ b/src/integrators/LangevinHullDynamics.cpp
@@ -160,4 +160,4 @@ namespace OpenMD {
 
   RealType LangevinHullDynamics::calcConservedQuantity() { return 0.0; }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/integrators/LangevinHullForceManager.hpp
+++ b/src/integrators/LangevinHullForceManager.hpp
@@ -102,5 +102,5 @@ namespace OpenMD {
     std::vector<StuntDouble*> localSites_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // LANGEVINHULL_FORCEMANAGER

--- a/src/integrators/LangevinHullForceModifier.hpp
+++ b/src/integrators/LangevinHullForceModifier.hpp
@@ -43,8 +43,8 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
-#ifndef INTEGRATOR_LANGEVINHULLFORCEMANAGER_HPP
-#define INTEGRATOR_LANGEVINHULLFORCEMANAGER_HPP
+#ifndef INTEGRATOR_LANGEVINHULLFORCEMODIFIER_HPP
+#define INTEGRATOR_LANGEVINHULLFORCEMODIFIER_HPP
 
 #include <map>
 #include <memory>
@@ -62,25 +62,24 @@ using namespace std;
 namespace OpenMD {
 
   /**
-   * @class LangevinHullForceManager
-   * Force manager for NPT Langevin Hull Dynamics applying friction
+   * @class LangevinHullForceModifier
+   * Force modifier for NPT Langevin Hull Dynamics applying friction
    * and random forces as well as torques.  Stochastic force is
    * determined by the area of surface triangles on the convex hull.
    * See: Vardeman, Stocker & Gezelter, J. Chem. Theory Comput. 7, 834 (2011),
    *      and Kohanoff et al. CHEMPHYSCHEM 6, 1848-1852 (2005).
    */
-  class LangevinHullForceManager : public ForceManager {
+  class LangevinHullForceModifier : public ForceModifier {
   public:
-    LangevinHullForceManager(SimInfo* info);
-    virtual ~LangevinHullForceManager();
+    LangevinHullForceModifier(SimInfo* info);
+    ~LangevinHullForceModifier();
 
-  protected:
-    virtual void postCalculation();
+    void modifyForces() override;
 
   private:
     std::vector<Vector3d> genTriangleForces(int nTriangles);
 
-    Globals* simParams;
+    Globals* simParams_;
     Utils::RandNumGenPtr randNumGen_;
     std::normal_distribution<RealType> forceDistribution_;
     std::unique_ptr<Velocitizer> veloMunge {nullptr};
@@ -101,6 +100,6 @@ namespace OpenMD {
     Hull* surfaceMesh_;
     std::vector<StuntDouble*> localSites_;
   };
-
 }  // namespace OpenMD
-#endif  // LANGEVINHULL_FORCEMANAGER
+
+#endif  // INTEGRATOR_LANGEVINHULLFORCEMODIFIER_HPP

--- a/src/integrators/LangevinPiston.cpp
+++ b/src/integrators/LangevinPiston.cpp
@@ -43,17 +43,18 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
-#ifdef IS_MPI
-#include <mpi.h>
-#endif
+#include "integrators/LangevinPiston.hpp"
 
 #include <cmath>
 #include <random>
 
+#ifdef IS_MPI
+#include <mpi.h>
+#endif
+
 #include "brains/SimInfo.hpp"
 #include "brains/Thermo.hpp"
 #include "integrators/IntegratorCreator.hpp"
-#include "integrators/LangevinPiston.hpp"
 #include "primitives/Molecule.hpp"
 #include "utils/Constants.hpp"
 #include "utils/simError.h"

--- a/src/integrators/LangevinPiston.hpp
+++ b/src/integrators/LangevinPiston.hpp
@@ -113,6 +113,6 @@ namespace OpenMD {
     RealType gamma_;
     RealType randomForce_;
   };
-}  // end namespace OpenMD
+}  // namespace OpenMD
 
 #endif  // INTEGRATORS_LANGEVINPISTON_HPP

--- a/src/integrators/NPA.hpp
+++ b/src/integrators/NPA.hpp
@@ -100,6 +100,6 @@ namespace OpenMD {
     Mat3x3d vScale;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 
 #endif  // INTEGRATORS_NPTF_HPP

--- a/src/integrators/NPAT.hpp
+++ b/src/integrators/NPAT.hpp
@@ -93,6 +93,6 @@ namespace OpenMD {
     unsigned int axis_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 
 #endif  // INTEGRATORS_NPTF_HPP

--- a/src/integrators/NPT.hpp
+++ b/src/integrators/NPT.hpp
@@ -156,6 +156,6 @@ namespace OpenMD {
     int maxIterNum_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 
 #endif  // INTEGRATORS_NPT_HPP

--- a/src/integrators/NPTf.hpp
+++ b/src/integrators/NPTf.hpp
@@ -87,6 +87,6 @@ namespace OpenMD {
     Mat3x3d vScale;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 
 #endif  // INTEGRATORS_NPTF_HPP

--- a/src/integrators/NPTi.hpp
+++ b/src/integrators/NPTi.hpp
@@ -85,6 +85,6 @@ namespace OpenMD {
     RealType vScale;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 
 #endif  // INTEGRATORS_NPTI_HPP

--- a/src/integrators/NPTxyz.hpp
+++ b/src/integrators/NPTxyz.hpp
@@ -67,6 +67,6 @@ namespace OpenMD {
     virtual void loadEta();
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 
 #endif  // INTEGRATORS_NPTXYZ_HPP

--- a/src/integrators/NPrT.hpp
+++ b/src/integrators/NPrT.hpp
@@ -94,6 +94,6 @@ namespace OpenMD {
     unsigned int axis_, axis1_, axis2_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 
 #endif  // INTEGRATORS_NPTF_HPP

--- a/src/integrators/NVE.cpp
+++ b/src/integrators/NVE.cpp
@@ -156,4 +156,4 @@ namespace OpenMD {
 
   RealType NVE::calcConservedQuantity() { return thermo.getTotalEnergy(); }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/integrators/NVE.hpp
+++ b/src/integrators/NVE.hpp
@@ -67,6 +67,6 @@ namespace OpenMD {
     virtual RealType calcConservedQuantity();
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 
 #endif

--- a/src/integrators/NVT.cpp
+++ b/src/integrators/NVT.cpp
@@ -269,4 +269,4 @@ namespace OpenMD {
     return conservedQuantity;
   }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/integrators/NVT.hpp
+++ b/src/integrators/NVT.hpp
@@ -103,6 +103,6 @@ namespace OpenMD {
     std::vector<Vector3d> oldJi_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 
 #endif  // INTEGRATOR_NVT_HPP

--- a/src/integrators/NgammaT.hpp
+++ b/src/integrators/NgammaT.hpp
@@ -94,6 +94,6 @@ namespace OpenMD {
     unsigned int axis_, axis1_, axis2_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 
 #endif

--- a/src/integrators/VelocityVerletIntegrator.hpp
+++ b/src/integrators/VelocityVerletIntegrator.hpp
@@ -60,5 +60,5 @@ namespace OpenMD {
     virtual void moveB() = 0;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // INTEGRATORS_VELOCITYVERLETINTEGRATOR_HPP

--- a/src/io/AtomTypesSectionParser.cpp
+++ b/src/io/AtomTypesSectionParser.cpp
@@ -107,4 +107,4 @@ namespace OpenMD {
     }
   }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/io/BaseAtomTypesSectionParser.cpp
+++ b/src/io/BaseAtomTypesSectionParser.cpp
@@ -102,4 +102,4 @@ namespace OpenMD {
     }
   }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/io/BendTypesSectionParser.cpp
+++ b/src/io/BendTypesSectionParser.cpp
@@ -92,4 +92,4 @@ namespace OpenMD {
 
     if (bendType != NULL) { ff.addBendType(at1, at2, at3, bendType); }
   }
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/io/ChargeAtomTypesSectionParser.cpp
+++ b/src/io/ChargeAtomTypesSectionParser.cpp
@@ -90,4 +90,4 @@ namespace OpenMD {
       }
     }
   }
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/io/ConstraintWriter.cpp
+++ b/src/io/ConstraintWriter.cpp
@@ -43,15 +43,16 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
-#ifdef IS_MPI
-#include <mpi.h>
-#endif
+#include "io/ConstraintWriter.hpp"
 
 #include <algorithm>
 #include <iostream>
 #include <vector>
 
-#include "io/ConstraintWriter.hpp"
+#ifdef IS_MPI
+#include <mpi.h>
+#endif
+
 #include "utils/simError.h"
 
 namespace OpenMD {

--- a/src/io/DirectionalAtomTypesSectionParser.cpp
+++ b/src/io/DirectionalAtomTypesSectionParser.cpp
@@ -96,4 +96,4 @@ namespace OpenMD {
       da.makeDirectional(I);
     }
   }
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/io/DumpReader.cpp
+++ b/src/io/DumpReader.cpp
@@ -746,4 +746,4 @@ namespace OpenMD {
       }
     }
   }
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/io/DumpReader.cpp
+++ b/src/io/DumpReader.cpp
@@ -46,9 +46,7 @@
 #define _LARGEFILE_SOURCE64
 #define _FILE_OFFSET_BITS 64
 
-#ifdef IS_MPI
-#include <mpi.h>
-#endif
+#include "io/DumpReader.hpp"
 
 #include <cmath>
 #include <cstdio>
@@ -59,8 +57,11 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#ifdef IS_MPI
+#include <mpi.h>
+#endif
+
 #include "brains/Thermo.hpp"
-#include "io/DumpReader.hpp"
 #include "primitives/Molecule.hpp"
 #include "utils/MemoryUtils.hpp"
 #include "utils/StringTokenizer.hpp"

--- a/src/io/DumpReader.hpp
+++ b/src/io/DumpReader.hpp
@@ -108,6 +108,6 @@ namespace OpenMD {
     char buffer[bufferSize];
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 
 #endif  // IO_DUMPREADER_HPP

--- a/src/io/DumpWriter.cpp
+++ b/src/io/DumpWriter.cpp
@@ -833,4 +833,4 @@ namespace OpenMD {
     os.flush();
   }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/io/DumpWriter.cpp
+++ b/src/io/DumpWriter.cpp
@@ -43,20 +43,21 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
-#include <config.h>
+#include "io/DumpWriter.hpp"
 
 #ifdef IS_MPI
 #include <mpi.h>
 #endif
 
-#include "io/DumpWriter.hpp"
+#include <config.h>
+
+#include "io/Globals.hpp"
 #include "io/basic_teebuf.hpp"
 #include "primitives/Molecule.hpp"
 #include "utils/simError.h"
 #ifdef HAVE_ZLIB
 #include "io/gzstream.hpp"
 #endif
-#include "io/Globals.hpp"
 
 using namespace std;
 namespace OpenMD {

--- a/src/io/EAMAtomTypesSectionParser.cpp
+++ b/src/io/EAMAtomTypesSectionParser.cpp
@@ -477,4 +477,4 @@ namespace OpenMD {
     }
   }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/io/GayBerneAtomTypesSectionParser.cpp
+++ b/src/io/GayBerneAtomTypesSectionParser.cpp
@@ -104,4 +104,4 @@ namespace OpenMD {
       }
     }
   }
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/io/Globals.hpp
+++ b/src/io/Globals.hpp
@@ -149,16 +149,13 @@ namespace OpenMD {
     DeclareParameter(Alpha, RealType);
     DeclareAlterableParameter(MDfileVersion, int);
     DeclareParameter(UniformField, std::vector<RealType>);
-    DeclareParameter(MagneticField, std::vector<RealType>)
-        DeclareParameter(UniformGradientStrength, RealType);
+    DeclareParameter(MagneticField, std::vector<RealType>);
+    DeclareParameter(UniformGradientStrength, RealType);
     DeclareParameter(UniformGradientDirection1, std::vector<RealType>);
     DeclareParameter(UniformGradientDirection2, std::vector<RealType>);
-
     DeclareParameter(ElectricField, std::vector<RealType>);
     DeclareParameter(ConstraintTime, RealType);
-
     DeclareParameter(PotentialSelection, std::string);
-
     DeclareParameter(PrivilegedAxis, std::string);
 
   public:

--- a/src/io/InversionTypesSectionParser.cpp
+++ b/src/io/InversionTypesSectionParser.cpp
@@ -97,4 +97,4 @@ namespace OpenMD {
       ff.addInversionType(at1, at2, at3, at4, inversionType);
     }
   }
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/io/LennardJonesAtomTypesSectionParser.cpp
+++ b/src/io/LennardJonesAtomTypesSectionParser.cpp
@@ -105,4 +105,4 @@ namespace OpenMD {
     }
   }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/io/MultipoleAtomTypesSectionParser.cpp
+++ b/src/io/MultipoleAtomTypesSectionParser.cpp
@@ -212,4 +212,4 @@ namespace OpenMD {
     }
   }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/io/NonBondedInteractionsSectionParser.cpp
+++ b/src/io/NonBondedInteractionsSectionParser.cpp
@@ -346,4 +346,4 @@ namespace OpenMD {
     return i == stringToEnumMap_.end() ? Unknown : i->second;
   }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/io/OptionSectionParser.cpp
+++ b/src/io/OptionSectionParser.cpp
@@ -80,4 +80,4 @@ namespace OpenMD {
     options_.validateOptions();
   }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/io/RestReader.cpp
+++ b/src/io/RestReader.cpp
@@ -427,4 +427,4 @@ namespace OpenMD {
     }
   }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/io/RestReader.cpp
+++ b/src/io/RestReader.cpp
@@ -43,9 +43,7 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
-#ifdef IS_MPI
-#include <mpi.h>
-#endif
+#include "io/RestReader.hpp"
 
 #include <cmath>
 #include <cstdio>
@@ -59,7 +57,10 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#include "io/RestReader.hpp"
+#ifdef IS_MPI
+#include <mpi.h>
+#endif
+
 #include "primitives/Molecule.hpp"
 #include "restraints/MolecularRestraint.hpp"
 #include "restraints/ObjectRestraint.hpp"

--- a/src/io/RestReader.hpp
+++ b/src/io/RestReader.hpp
@@ -132,6 +132,6 @@ namespace OpenMD {
     char buffer[bufferSize];
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 
 #endif  // IO_RESTREADER_HPP

--- a/src/io/RestWriter.cpp
+++ b/src/io/RestWriter.cpp
@@ -43,16 +43,17 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
-#ifdef IS_MPI
-#include <mpi.h>
-#endif
+#include "io/RestWriter.hpp"
 
 #include <iostream>
 #include <sstream>
 #include <string>
 
+#ifdef IS_MPI
+#include <mpi.h>
+#endif
+
 #include "brains/SnapshotManager.hpp"
-#include "io/RestWriter.hpp"
 #include "utils/simError.h"
 
 namespace OpenMD {

--- a/src/io/RestWriter.cpp
+++ b/src/io/RestWriter.cpp
@@ -292,4 +292,4 @@ namespace OpenMD {
 
   void RestWriter::writeClosing(std::ostream& os) { os.flush(); }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/io/SCAtomTypesSectionParser.cpp
+++ b/src/io/SCAtomTypesSectionParser.cpp
@@ -98,4 +98,4 @@ namespace OpenMD {
       }
     }
   }
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/io/ShapeAtomTypesSectionParser.cpp
+++ b/src/io/ShapeAtomTypesSectionParser.cpp
@@ -316,4 +316,4 @@ namespace OpenMD {
         std::shared_ptr<GenericData>(new ShapeAtypeData("Shape", st)));
     //  delete shapeStream;
   }
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/io/StickyAtomTypesSectionParser.cpp
+++ b/src/io/StickyAtomTypesSectionParser.cpp
@@ -101,4 +101,4 @@ namespace OpenMD {
       }
     }
   }
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/io/StickyPowerAtomTypesSectionParser.cpp
+++ b/src/io/StickyPowerAtomTypesSectionParser.cpp
@@ -102,4 +102,4 @@ namespace OpenMD {
       }
     }
   }
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/io/TorsionTypesSectionParser.cpp
+++ b/src/io/TorsionTypesSectionParser.cpp
@@ -104,4 +104,4 @@ namespace OpenMD {
       ff.addTorsionType(at1, at2, at3, at4, torsionType);
     }
   }
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/io/UFFAtomTypesSectionParser.cpp
+++ b/src/io/UFFAtomTypesSectionParser.cpp
@@ -157,4 +157,4 @@ namespace OpenMD {
     //     // ka now represents the xij in equation 20 -- the expected vdw
     //     distance kaSquared = (Ra * Rb); ka = sqrt(kaSquared);
   }
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/io/ZConsWriter.cpp
+++ b/src/io/ZConsWriter.cpp
@@ -43,15 +43,16 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
-#ifdef IS_MPI
-#include <mpi.h>
-#endif
+#include "io/ZConsWriter.hpp"
 
 #include <algorithm>
 #include <iostream>
 #include <vector>
 
-#include "io/ZConsWriter.hpp"
+#ifdef IS_MPI
+#include <mpi.h>
+#endif
+
 #include "utils/simError.h"
 
 namespace OpenMD {

--- a/src/io/ifstrstream.cpp
+++ b/src/io/ifstrstream.cpp
@@ -50,11 +50,11 @@
  * @version 1.0
  */
 
+#include "io/ifstrstream.hpp"
+
 #ifdef IS_MPI
 #include <mpi.h>
 #endif
-
-#include "io/ifstrstream.hpp"
 
 namespace OpenMD {
 

--- a/src/math/AlphaHull.cpp
+++ b/src/math/AlphaHull.cpp
@@ -43,11 +43,7 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
-#ifdef IS_MPI
-#include <mpi.h>
-#endif
-
-/* Standard includes independent of library */
+#include "math/AlphaHull.hpp"
 
 #include <algorithm>
 #include <fstream>
@@ -55,7 +51,10 @@
 #include <iterator>
 #include <list>
 
-#include "math/AlphaHull.hpp"
+#ifdef IS_MPI
+#include <mpi.h>
+#endif
+
 #include "math/qhull.hpp"
 #include "utils/simError.h"
 

--- a/src/math/ChebyshevT.cpp
+++ b/src/math/ChebyshevT.cpp
@@ -77,4 +77,4 @@ namespace OpenMD {
     polyList_.push_back(t1);
   }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/math/ChebyshevT.hpp
+++ b/src/math/ChebyshevT.hpp
@@ -116,5 +116,5 @@ namespace OpenMD {
     int maxPower_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // MATH_CHEBYSHEVT_HPP

--- a/src/math/ChebyshevU.cpp
+++ b/src/math/ChebyshevU.cpp
@@ -77,4 +77,4 @@ namespace OpenMD {
     polyList_.push_back(u1);
   }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/math/ChebyshevU.hpp
+++ b/src/math/ChebyshevU.hpp
@@ -116,5 +116,5 @@ namespace OpenMD {
     int maxPower_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // MATH_CHEBYSHEVU_HPP

--- a/src/math/ConvexHull.cpp
+++ b/src/math/ConvexHull.cpp
@@ -43,11 +43,7 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
-#ifdef IS_MPI
-#include <mpi.h>
-#endif
-
-/* Standard includes independent of library */
+#include "math/ConvexHull.hpp"
 
 #include <algorithm>
 #include <fstream>
@@ -55,7 +51,10 @@
 #include <iterator>
 #include <list>
 
-#include "math/ConvexHull.hpp"
+#ifdef IS_MPI
+#include <mpi.h>
+#endif
+
 #include "math/qhull.hpp"
 #include "utils/simError.h"
 

--- a/src/math/Polynomial.hpp
+++ b/src/math/Polynomial.hpp
@@ -642,5 +642,5 @@ namespace OpenMD {
 
   typedef Polynomial<RealType> DoublePolynomial;
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // MATH_POLYNOMIAL_HPP

--- a/src/math/Triangle.hpp
+++ b/src/math/Triangle.hpp
@@ -193,6 +193,6 @@ namespace OpenMD {
 
   };  // End class Triangle
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 
 #endif  // MATH_FACET_HPP

--- a/src/nonbonded/Electrostatic.cpp
+++ b/src/nonbonded/Electrostatic.cpp
@@ -43,9 +43,7 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
-#ifdef IS_MPI
-#include <mpi.h>
-#endif
+#include "nonbonded/Electrostatic.hpp"
 
 #include <cmath>
 #include <cstdio>
@@ -53,11 +51,14 @@
 #include <memory>
 #include <numeric>
 
+#ifdef IS_MPI
+#include <mpi.h>
+#endif
+
 #include "flucq/FluctuatingChargeForces.hpp"
 #include "io/Globals.hpp"
 #include "math/SquareMatrix.hpp"
 #include "math/erfc.hpp"
-#include "nonbonded/Electrostatic.hpp"
 #include "nonbonded/SlaterIntegrals.hpp"
 #include "primitives/Molecule.hpp"
 #include "types/FixedChargeAdapter.hpp"

--- a/src/nonbonded/InteractionManager.cpp
+++ b/src/nonbonded/InteractionManager.cpp
@@ -635,4 +635,4 @@ namespace OpenMD {
     }
     return cutoff;
   }
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/nonbonded/NonBondedInteraction.hpp
+++ b/src/nonbonded/NonBondedInteraction.hpp
@@ -253,5 +253,5 @@ namespace OpenMD {
     virtual InteractionFamily getFamily() { return HYDROGENBONDING_FAMILY; }
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif

--- a/src/optimization/PotentialEnergyObjectiveFunction.cpp
+++ b/src/optimization/PotentialEnergyObjectiveFunction.cpp
@@ -44,8 +44,9 @@
  */
 
 #include "optimization/PotentialEnergyObjectiveFunction.hpp"
+
 #ifdef IS_MPI
-#include "mpi.h"
+#include <mpi.h>
 #endif
 
 namespace OpenMD {

--- a/src/parallel/ForceDecomposition.cpp
+++ b/src/parallel/ForceDecomposition.cpp
@@ -43,12 +43,13 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
+#include "parallel/ForceDecomposition.hpp"
+
 #ifdef IS_MPI
 #include <mpi.h>
 #endif
 
 #include "math/Vector3.hpp"
-#include "parallel/ForceDecomposition.hpp"
 
 using namespace std;
 namespace OpenMD {

--- a/src/parallel/ForceMatrixDecomposition.cpp
+++ b/src/parallel/ForceMatrixDecomposition.cpp
@@ -1652,4 +1652,4 @@ namespace OpenMD {
     return atom1;
 #endif
   }
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/perturbations/MagneticField.cpp
+++ b/src/perturbations/MagneticField.cpp
@@ -45,6 +45,7 @@
 
 #include "perturbations/MagneticField.hpp"
 
+#include "brains/ForceModifier.hpp"
 #include "nonbonded/NonBondedInteraction.hpp"
 #include "primitives/Molecule.hpp"
 #include "types/FixedChargeAdapter.hpp"
@@ -54,7 +55,7 @@
 namespace OpenMD {
 
   MagneticField::MagneticField(SimInfo* info) :
-      initialized(false), doMagneticField(false), info_(info) {
+      ForceModifier {info}, initialized {false}, doMagneticField {false} {
     simParams = info_->getSimParams();
   }
 
@@ -80,7 +81,7 @@ namespace OpenMD {
     initialized = true;
   }
 
-  void MagneticField::applyPerturbation() {
+  void MagneticField::modifyForces() {
     if (!initialized) initialize();
 
     SimInfo::MoleculeIterator i;

--- a/src/perturbations/MagneticField.hpp
+++ b/src/perturbations/MagneticField.hpp
@@ -50,8 +50,8 @@
 #ifndef PERTURBATIONS_MAGNETICFIELD_HPP
 #define PERTURBATIONS_MAGNETICFIELD_HPP
 
+#include "brains/ForceModifier.hpp"
 #include "brains/SimInfo.hpp"
-#include "perturbations/Perturbation.hpp"
 
 namespace OpenMD {
 
@@ -79,21 +79,20 @@ namespace OpenMD {
    (\mathbf{\omega} \times \mathbf{D} ) \times \mathbf{B} \f$
 
   */
-  class MagneticField : public Perturbation {
+  class MagneticField : public ForceModifier {
   public:
     MagneticField(SimInfo* info);
 
-  protected:
-    virtual void initialize();
-    virtual void applyPerturbation();
-
   private:
+    void modifyForces() override;
+    void initialize();
+
     bool initialized;
     bool doMagneticField;
+
     Globals* simParams;
-    SimInfo* info_ {nullptr};
     Vector3d MF;
   };
-
 }  // namespace OpenMD
+
 #endif

--- a/src/perturbations/MagneticField.hpp
+++ b/src/perturbations/MagneticField.hpp
@@ -95,5 +95,5 @@ namespace OpenMD {
     Vector3d MF;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif

--- a/src/perturbations/UniformField.cpp
+++ b/src/perturbations/UniformField.cpp
@@ -45,21 +45,23 @@
 
 #include "perturbations/UniformField.hpp"
 
+#ifdef IS_MPI
+#include <mpi.h>
+#endif
+
+#include "brains/ForceModifier.hpp"
 #include "nonbonded/NonBondedInteraction.hpp"
 #include "primitives/Molecule.hpp"
 #include "types/FixedChargeAdapter.hpp"
 #include "types/FluctuatingChargeAdapter.hpp"
 #include "types/MultipoleAdapter.hpp"
 #include "utils/Constants.hpp"
-#ifdef IS_MPI
-#include "mpi.h"
-#endif
 
 namespace OpenMD {
 
   UniformField::UniformField(SimInfo* info) :
-      initialized(false), doUniformField(false), doParticlePot(false),
-      info_(info) {
+      ForceModifier {info}, initialized {false}, doUniformField {false},
+      doParticlePot {false} {
     simParams = info_->getSimParams();
   }
 
@@ -91,7 +93,7 @@ namespace OpenMD {
     initialized = true;
   }
 
-  void UniformField::applyPerturbation() {
+  void UniformField::modifyForces() {
     if (!initialized) initialize();
 
     SimInfo::MoleculeIterator i;

--- a/src/perturbations/UniformField.hpp
+++ b/src/perturbations/UniformField.hpp
@@ -50,8 +50,8 @@
 #ifndef PERTURBATIONS_UNIFORMFIELD_HPP
 #define PERTURBATIONS_UNIFORMFIELD_HPP
 
+#include "brains/ForceModifier.hpp"
 #include "brains/SimInfo.hpp"
-#include "perturbations/Perturbation.hpp"
 
 namespace OpenMD {
 
@@ -81,22 +81,21 @@ namespace OpenMD {
    potential, \f$ U = - \mathbf{D} \cdot \mathbf{E} \f$ and a torque,
    \f$ \mathbf{\tau} = \mathbf{D} \times \mathbf{E} \f$.
   */
-  class UniformField : public Perturbation {
+  class UniformField : public ForceModifier {
   public:
     UniformField(SimInfo* info);
 
-  protected:
-    virtual void initialize();
-    virtual void applyPerturbation();
-
   private:
+    void modifyForces() override;
+    void initialize();
+
     bool initialized;
     bool doUniformField;
     bool doParticlePot;
+
     Globals* simParams;
-    SimInfo* info_ {nullptr};
     Vector3d EF;
   };
-
 }  // namespace OpenMD
+
 #endif

--- a/src/perturbations/UniformField.hpp
+++ b/src/perturbations/UniformField.hpp
@@ -98,5 +98,5 @@ namespace OpenMD {
     Vector3d EF;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif

--- a/src/perturbations/UniformGradient.cpp
+++ b/src/perturbations/UniformGradient.cpp
@@ -45,21 +45,22 @@
 
 #include "perturbations/UniformGradient.hpp"
 
+#ifdef IS_MPI
+#include <mpi.h>
+#endif
+
+#include "brains/ForceModifier.hpp"
 #include "nonbonded/NonBondedInteraction.hpp"
 #include "primitives/Molecule.hpp"
 #include "types/FixedChargeAdapter.hpp"
 #include "types/FluctuatingChargeAdapter.hpp"
 #include "types/MultipoleAdapter.hpp"
 #include "utils/Constants.hpp"
-#ifdef IS_MPI
-#include "mpi.h"
-#endif
 
 namespace OpenMD {
-
   UniformGradient::UniformGradient(SimInfo* info) :
-      initialized(false), doUniformGradient(false), doParticlePot(false),
-      info_(info) {
+      ForceModifier {info}, initialized {false}, doUniformGradient {false},
+      doParticlePot {false} {
     simParams = info_->getSimParams();
   }
 
@@ -153,7 +154,7 @@ namespace OpenMD {
     initialized = true;
   }
 
-  void UniformGradient::applyPerturbation() {
+  void UniformGradient::modifyForces() {
     if (!initialized) initialize();
 
     SimInfo::MoleculeIterator i;

--- a/src/perturbations/UniformGradient.hpp
+++ b/src/perturbations/UniformGradient.hpp
@@ -50,8 +50,8 @@
 #ifndef PERTURBATIONS_UNIFORMGRADIENT_HPP
 #define PERTURBATIONS_UNIFORMGRADIENT_HPP
 
+#include "brains/ForceModifier.hpp"
 #include "brains/SimInfo.hpp"
-#include "perturbations/Perturbation.hpp"
 
 namespace OpenMD {
 
@@ -120,20 +120,19 @@ namespace OpenMD {
     \f$ \mathbf{F} = 2 \mathsf{Q} \times \nabla \mathbf{E} \f$
 
   */
-  class UniformGradient : public Perturbation {
+  class UniformGradient : public ForceModifier {
   public:
     UniformGradient(SimInfo* info);
 
-  protected:
-    virtual void initialize();
-    virtual void applyPerturbation();
-
   private:
+    void modifyForces() override;
+    void initialize();
+
     bool initialized;
     bool doUniformGradient;
     bool doParticlePot;
+
     Globals* simParams;
-    SimInfo* info_ {nullptr};
     Mat3x3d Grad_;
     Vector3d a_, b_;
     RealType g_, cpsi_;

--- a/src/perturbations/UniformGradient.hpp
+++ b/src/perturbations/UniformGradient.hpp
@@ -139,5 +139,5 @@ namespace OpenMD {
     RealType g_, cpsi_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif

--- a/src/primitives/Bend.cpp
+++ b/src/primitives/Bend.cpp
@@ -113,4 +113,4 @@ namespace OpenMD {
     angle = theta / Constants::PI * 180.0;
   }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/primitives/Bend.hpp
+++ b/src/primitives/Bend.hpp
@@ -130,5 +130,5 @@ namespace OpenMD {
     BendType* bendType_; /**< bend type */
     std::string name_;
   };
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // PRIMITIVES_BEND_HPP

--- a/src/primitives/Bond.hpp
+++ b/src/primitives/Bond.hpp
@@ -116,5 +116,5 @@ namespace OpenMD {
     BondType* bondType_; /**< bond type */
     std::string name_;
   };
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // PRIMITIVES_BOND_HPP

--- a/src/primitives/CutoffGroup.hpp
+++ b/src/primitives/CutoffGroup.hpp
@@ -155,5 +155,5 @@ namespace OpenMD {
     DataStoragePointer storage_;
     SnapshotManager* snapshotMan_;
   };
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // PRIMITIVES_CUTOFFGROUP_HPP

--- a/src/primitives/GhostBend.cpp
+++ b/src/primitives/GhostBend.cpp
@@ -111,4 +111,4 @@ namespace OpenMD {
 
     angle = theta / Constants::PI * 180.0;
   }
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/primitives/GhostBend.hpp
+++ b/src/primitives/GhostBend.hpp
@@ -65,5 +65,5 @@ namespace OpenMD {
 
     virtual void calcForce(RealType& angle, bool doParticlePot);
   };
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // PRIMITIVES_GHOSTBEND_HPP

--- a/src/primitives/GhostTorsion.hpp
+++ b/src/primitives/GhostTorsion.hpp
@@ -66,6 +66,6 @@ namespace OpenMD {
     virtual void calcForce(RealType& angle, bool doParticlePot);
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 
 #endif  // PRIMITIVES_GHOSTBEND_HPP

--- a/src/primitives/Molecule.cpp
+++ b/src/primitives/Molecule.cpp
@@ -415,4 +415,4 @@ namespace OpenMD {
     return o;
   }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/primitives/ShortRangeInteraction.hpp
+++ b/src/primitives/ShortRangeInteraction.hpp
@@ -185,5 +185,5 @@ namespace OpenMD {
     PropertyMap properties_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // PRIMITIVES_STUNTDOUBLE_HPP

--- a/src/primitives/StuntDouble.hpp
+++ b/src/primitives/StuntDouble.hpp
@@ -1595,5 +1595,5 @@ namespace OpenMD {
     PropertyMap properties_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // PRIMITIVES_STUNTDOUBLE_HPP

--- a/src/primitives/UreyBradleyBend.cpp
+++ b/src/primitives/UreyBradleyBend.cpp
@@ -61,4 +61,4 @@ namespace OpenMD {
     if (doParticlePot) { atoms_[1]->addParticlePot(bond_->getPotential()); }
   }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/primitives/UreyBradleyBend.hpp
+++ b/src/primitives/UreyBradleyBend.hpp
@@ -75,6 +75,6 @@ namespace OpenMD {
     Bond* bond_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 
 #endif  // PRIMITIVES_UREYBRADLEYBEND_HPP

--- a/src/restraints/MolecularRestraint.cpp
+++ b/src/restraints/MolecularRestraint.cpp
@@ -147,13 +147,12 @@ namespace OpenMD {
       RotMat3x3d Atrans = v * w_tr.transpose();
       RotMat3x3d A      = Atrans.transpose();
 
-      RealType twistAngle;
-      Vector3d swingAxis;
-
       Quat4d quat = A.toQuaternion();
 
+      RealType twistAngle;
       RealType swingX, swingY;
-      quat.toSwingTwist(swingX, swingY, twistAngle);
+
+      quat.toTwistSwing(twistAngle, swingX, swingY);
 
       RealType dVdtwist, dVdswingX, dVdswingY;
       RealType dTwist, dSwingX, dSwingY;

--- a/src/restraints/ObjectRestraint.cpp
+++ b/src/restraints/ObjectRestraint.cpp
@@ -57,7 +57,7 @@ namespace OpenMD {
       Vector3d frc = -kDisp_ * del;
       RealType p   = 0.5 * kDisp_ * del.lengthSquare();
 
-      pot_ = p;
+      pot_ += p;
       force_ += frc * scaleFactor_;
       if (printRest_) restInfo_[rtDisplacement] = std::make_pair(r, p);
     }
@@ -85,10 +85,9 @@ namespace OpenMD {
       Quat4d quat     = temp.toQuaternion();
 
       RealType twistAngle;
-      Vector3d swingAxis;
       RealType swingX, swingY;
 
-      quat.toSwingTwist(swingX, swingY, twistAngle);
+      quat.toTwistSwing(twistAngle, swingX, swingY);
 
       RealType p;
       Vector3d tTwist, tSwing;
@@ -101,6 +100,7 @@ namespace OpenMD {
         p                 = 0.5 * kTwist_ * dTwist * dTwist;
         pot_ += p;
         tBody -= dVdtwist * V3Z;
+
         if (printRest_) restInfo_[rtTwist] = std::make_pair(twistAngle, p);
       }
 

--- a/src/restraints/ObjectRestraint.cpp
+++ b/src/restraints/ObjectRestraint.cpp
@@ -128,7 +128,6 @@ namespace OpenMD {
 
       Vector3d tLab = A.transpose() * tBody;
       torque_       = tLab * scaleFactor_;
-
     }
   }
 }  // namespace OpenMD

--- a/src/restraints/RestraintForceModifier.cpp
+++ b/src/restraints/RestraintForceModifier.cpp
@@ -312,11 +312,11 @@ namespace OpenMD {
     // ThermodynamicIntegration subclasses RestraintForceManager, and there
     // are times when it won't use restraints at all, so only open the
     // restraint file if we are actually using restraints:
-
     if (simParam->getUseRestraints()) {
       std::string refFile = simParam->getRestraint_file();
       RestReader* rr      = new RestReader(info, refFile, stuntDoubleIndex);
       rr->readReferenceStructure();
+      delete rr;
     }
 
     restOutput_ = getPrefix(info_->getFinalConfigFileName()) + ".rest";

--- a/src/restraints/RestraintForceModifier.cpp
+++ b/src/restraints/RestraintForceModifier.cpp
@@ -353,10 +353,6 @@ namespace OpenMD {
 
     currSnapshot_ = info_->getSnapshotManager()->getCurrentSnapshot();
     currSnapshot_->setRestraintPotential(restPot);
-    
-    RealType pe = currSnapshot_->getPotentialEnergy();
-    currSnapshot_->setRawPotential( pe );
-    currSnapshot_->setPotentialEnergy( pe + restPot );
 
     RealType pe = currSnapshot_->getPotentialEnergy();
     currSnapshot_->setRawPotential(pe);
@@ -499,7 +495,7 @@ namespace OpenMD {
         oRest->calcForce(pos, A);
         (*ro)->addFrc(oRest->getRestraintForce());
         (*ro)->addTrq(oRest->getRestraintTorque());
-	
+
       } else {
         // plain vanilla positional restraints:
 

--- a/src/restraints/RestraintForceModifier.cpp
+++ b/src/restraints/RestraintForceModifier.cpp
@@ -43,29 +43,32 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
-#ifdef IS_MPI
-#include <mpi.h>
-#endif
+#include "restraints/RestraintForceModifier.hpp"
 
 #include <config.h>
 
 #include <cmath>
 #include <memory>
 
+#ifdef IS_MPI
+#include <mpi.h>
+#endif
+
+#include "brains/ForceModifier.hpp"
 #include "io/RestReader.hpp"
 #include "restraints/MolecularRestraint.hpp"
 #include "restraints/ObjectRestraint.hpp"
-#include "restraints/RestraintForceManager.hpp"
 #include "selection/SelectionEvaluator.hpp"
 #include "selection/SelectionManager.hpp"
 #include "utils/Constants.hpp"
+#include "utils/MemoryUtils.hpp"
 #include "utils/StringUtils.hpp"
 #include "utils/simError.h"
 
 namespace OpenMD {
 
-  RestraintForceManager::RestraintForceManager(SimInfo* info) :
-      ForceManager(info) {
+  RestraintForceModifier::RestraintForceModifier(SimInfo* info) :
+      ForceModifier {info} {
     // order of affairs:
     //
     // 1) create restraints from the restraintStamps found in the MD
@@ -79,8 +82,10 @@ namespace OpenMD {
     // call the normal force manager calcForces, then loop through the
     // restrained objects and do their restraint forces.
 
-    currSnapshot_     = info_->getSnapshotManager()->getCurrentSnapshot();
     Globals* simParam = info_->getSimParams();
+    currSnapshot_     = info_->getSnapshotManager()->getCurrentSnapshot();
+
+    currRestTime_ = currSnapshot_->getTime();
 
     if (simParam->haveStatusTime()) {
       restTime_ = simParam->getStatusTime();
@@ -330,21 +335,13 @@ namespace OpenMD {
     }
   }
 
-  RestraintForceManager::~RestraintForceManager() {
+  RestraintForceModifier::~RestraintForceModifier() {
+    Utils::deletePointers(restraints_);
+
     delete restOut;
-    std::vector<Restraint*>::const_iterator resti;
-    for (resti = restraints_.begin(); resti != restraints_.end(); ++resti) {
-      delete (*resti);
-    }
-    restraints_.clear();
   }
 
-  void RestraintForceManager::init() {
-    currRestTime_ = currSnapshot_->getTime();
-  }
-
-  void RestraintForceManager::calcForces() {
-    ForceManager::calcForces();
+  void RestraintForceModifier::modifyForces() {
     RealType restPot(0.0);
 
     restPot = doRestraints(1.0);
@@ -357,6 +354,10 @@ namespace OpenMD {
     currSnapshot_ = info_->getSnapshotManager()->getCurrentSnapshot();
     currSnapshot_->setRestraintPotential(restPot);
 
+    RealType pe = currSnapshot_->getPotentialEnergy();
+    currSnapshot_->setRawPotential(pe);
+    currSnapshot_->setPotentialEnergy(pe + restPot);
+
     // write out forces and current positions of restrained molecules
     if (currSnapshot_->getTime() >= currRestTime_) {
       restOut->writeRest(restInfo_);
@@ -364,7 +365,7 @@ namespace OpenMD {
     }
   }
 
-  RealType RestraintForceManager::doRestraints(RealType scalingFactor) {
+  RealType RestraintForceModifier::doRestraints(RealType scalingFactor) {
     std::vector<Molecule*>::const_iterator rm;
     std::shared_ptr<GenericData> data;
     Molecule::IntegrableObjectIterator ioi;

--- a/src/restraints/RestraintForceModifier.hpp
+++ b/src/restraints/RestraintForceModifier.hpp
@@ -43,18 +43,44 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
-#ifndef PERTURBATIONS_PERTURBATION_HPP
-#define PERTURBATIONS_PERTURBATION_HPP
+#ifndef RESTRAINTS_RESTRAINTFORCEMODIFIER_HPP
+#define RESTRAINTS_RESTRAINTFORCEMODIFIER_HPP
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "brains/ForceModifier.hpp"
+#include "brains/Snapshot.hpp"
+#include "io/RestWriter.hpp"
+#include "restraints/Restraint.hpp"
 
 namespace OpenMD {
 
-  //! Abstract class for external perturbation classes
-  class Perturbation {
+  class RestraintForceModifier : public ForceModifier {
   public:
-    virtual ~Perturbation() {}
-    virtual void applyPerturbation() = 0;
-  };
+    RestraintForceModifier(SimInfo* info);
+    virtual ~RestraintForceModifier();
 
+    void modifyForces() override;
+
+  protected:
+    RealType doRestraints(RealType scalingFactor);
+    RealType getUnscaledPotential() { return unscaledPotential_; }
+
+  private:
+    std::vector<Restraint*> restraints_;
+    std::vector<Molecule*> restrainedMols_;
+    std::vector<StuntDouble*> restrainedObjs_;
+    RealType unscaledPotential_;
+
+    std::vector<std::map<int, Restraint::RealPair>> restInfo_;
+    std::string restOutput_;
+    RealType currRestTime_;
+    RealType restTime_;
+    RestWriter* restOut;
+    Snapshot* currSnapshot_;
+  };
 }  // namespace OpenMD
 
-#endif
+#endif  // RESTRAINTS_RESTRAINTFORCEMODIFIER_HPP

--- a/src/restraints/ThermoIntegrationForceModifier.hpp
+++ b/src/restraints/ThermoIntegrationForceModifier.hpp
@@ -43,41 +43,28 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
-#ifndef RESTRAINTS_RESTRAINTFORCEMANAGER_HPP
-#define RESTRAINTS_RESTRAINTFORCEMANAGER_HPP
+#ifndef RESTRAINTS_THERMOINTEGRATIONFORCEMODIFIER_HPP
+#define RESTRAINTS_THERMOINTEGRATIONFORCEMODIFIER_HPP
 
-#include <vector>
-
-#include "brains/ForceManager.hpp"
-#include "io/RestWriter.hpp"
-#include "restraints/Restraint.hpp"
+#include "brains/Snapshot.hpp"
+#include "restraints/RestraintForceModifier.hpp"
 
 namespace OpenMD {
 
-  class RestraintForceManager : public ForceManager {
+  class ThermoIntegrationForceModifier : public RestraintForceModifier {
   public:
-    RestraintForceManager(SimInfo* info);
-    ~RestraintForceManager();
+    ThermoIntegrationForceModifier(SimInfo* info);
 
-    virtual void init();
-    virtual void calcForces();
-
-    RealType doRestraints(RealType scalingFactor);
-    RealType getUnscaledPotential() { return unscaledPotential_; }
+    void modifyForces() override;
 
   private:
-    std::vector<Restraint*> restraints_;
-    std::vector<Molecule*> restrainedMols_;
-    std::vector<StuntDouble*> restrainedObjs_;
-    RealType unscaledPotential_;
-
-    std::vector<std::map<int, Restraint::RealPair>> restInfo_;
-    std::string restOutput_;
-    RealType currRestTime_;
-    RealType restTime_;
-    RestWriter* restOut;
+    Globals* simParam_;
     Snapshot* currSnapshot_;
-  };
 
+    RealType factor_;
+    RealType lrPot_;
+    RealType vHarm_;
+  };
 }  // namespace OpenMD
-#endif
+
+#endif  // RESTRAINTS_THERMOINTEGRATIONFORCEMODIFIER_HPP

--- a/src/rnemd/NIVS.cpp
+++ b/src/rnemd/NIVS.cpp
@@ -43,6 +43,8 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
+#include "rnemd/NIVS.hpp"
+
 #include <algorithm>
 #include <cmath>
 #include <map>
@@ -65,7 +67,6 @@
 #include "math/Vector3.hpp"
 #include "primitives/Molecule.hpp"
 #include "primitives/StuntDouble.hpp"
-#include "rnemd/NIVS.hpp"
 #include "rnemd/RNEMD.hpp"
 #include "rnemd/RNEMDParameters.hpp"
 #include "types/FixedChargeAdapter.hpp"
@@ -608,7 +609,7 @@ namespace OpenMD {
       }
       if (successfulScale != true) {
         sprintf(painCave.errMsg,
-                "RNEMD::doNIVS exchange NOT performed - roots that solve\n"
+                "NIVS exchange NOT performed - roots that solve\n"
                 "\tthe constraint equations may not exist or there may be\n"
                 "\tno selected objects in one or both slabs.\n");
         painCave.isFatal  = 0;

--- a/src/rnemd/RNEMD.cpp
+++ b/src/rnemd/RNEMD.cpp
@@ -43,6 +43,8 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
+#include "rnemd/RNEMD.hpp"
+
 #include <algorithm>
 #include <cmath>
 #include <map>
@@ -65,7 +67,6 @@
 #include "math/Vector3.hpp"
 #include "primitives/Molecule.hpp"
 #include "primitives/StuntDouble.hpp"
-#include "rnemd/RNEMD.hpp"
 #include "rnemd/RNEMDParameters.hpp"
 #include "types/FixedChargeAdapter.hpp"
 #include "types/FluctuatingChargeAdapter.hpp"

--- a/src/rnemd/Swap.cpp
+++ b/src/rnemd/Swap.cpp
@@ -43,6 +43,8 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
+#include "rnemd/Swap.hpp"
+
 #include <algorithm>
 #include <cmath>
 #include <map>
@@ -67,7 +69,6 @@
 #include "primitives/StuntDouble.hpp"
 #include "rnemd/RNEMD.hpp"
 #include "rnemd/RNEMDParameters.hpp"
-#include "rnemd/Swap.hpp"
 #include "types/FixedChargeAdapter.hpp"
 #include "types/FluctuatingChargeAdapter.hpp"
 #include "utils/Accumulator.hpp"
@@ -505,7 +506,7 @@ namespace OpenMD {
         }
       } else {
         sprintf(painCave.errMsg,
-                "RNEMD::doSwap exchange NOT performed because selected object\n"
+                "Swap exchange NOT performed because selected object\n"
                 "\twas not present in at least one of the two slabs.\n");
         painCave.isFatal  = 0;
         painCave.severity = OPENMD_INFO;

--- a/src/rnemd/VSS.cpp
+++ b/src/rnemd/VSS.cpp
@@ -43,6 +43,8 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
+#include "rnemd/VSS.hpp"
+
 #include <algorithm>
 #include <cmath>
 #include <map>
@@ -67,7 +69,6 @@
 #include "primitives/StuntDouble.hpp"
 #include "rnemd/RNEMD.hpp"
 #include "rnemd/RNEMDParameters.hpp"
-#include "rnemd/VSS.hpp"
 #include "types/FixedChargeAdapter.hpp"
 #include "types/FluctuatingChargeAdapter.hpp"
 #include "utils/Accumulator.hpp"
@@ -499,7 +500,7 @@ namespace OpenMD {
 
       if (successfulExchange != true) {
         sprintf(painCave.errMsg,
-                "RNEMD::doVSS exchange NOT performed - roots that solve\n"
+                "VSS exchange NOT performed - roots that solve\n"
                 "\tthe constraint equations may not exist or there may be\n"
                 "\tno selected objects in one or both slabs.\n");
         painCave.isFatal  = 0;

--- a/src/selection/DistanceFinder.cpp
+++ b/src/selection/DistanceFinder.cpp
@@ -43,12 +43,13 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
+#include "selection/DistanceFinder.hpp"
+
 #ifdef IS_MPI
 #include <mpi.h>
 #endif
 
 #include "primitives/Molecule.hpp"
-#include "selection/DistanceFinder.hpp"
 
 namespace OpenMD {
 

--- a/src/selection/SelectionManager.cpp
+++ b/src/selection/SelectionManager.cpp
@@ -45,10 +45,11 @@
 
 #include "selection/SelectionManager.hpp"
 
-#include "brains/SimInfo.hpp"
 #ifdef IS_MPI
 #include <mpi.h>
 #endif
+
+#include "brains/SimInfo.hpp"
 
 namespace OpenMD {
   SelectionManager::SelectionManager(SimInfo* info) : info_(info) {

--- a/src/selection/SelectionManager.cpp
+++ b/src/selection/SelectionManager.cpp
@@ -68,7 +68,7 @@ namespace OpenMD {
     molecules_.resize(nObjects_[MOLECULE]);
 
     ss_.resize(nObjects_);
-    
+
     SimInfo::MoleculeIterator mi;
     Molecule::AtomIterator ai;
     Molecule::RigidBodyIterator rbIter;
@@ -536,7 +536,6 @@ namespace OpenMD {
     return i == -1 ? NULL : molecules_[i];
 #endif
   }
-  
 
   /**
    * getSelectedAtomTypes

--- a/src/selection/SelectionManager.hpp
+++ b/src/selection/SelectionManager.hpp
@@ -476,7 +476,7 @@ namespace OpenMD {
      * @param i iterator used to keep track of the selection
      */
     Molecule* nextUnselectedMolecule(int& i);
-    
+
     /**
      * Finds the n^th selected Molecule in the selection. In parallel,
      * if this molecule is not the responsibility of the local
@@ -486,7 +486,7 @@ namespace OpenMD {
      * @param n which molecule in the selection set to find
      */
     Molecule* nthSelectedMolecule(int& n);
-    
+
     std::set<AtomType*> getSelectedAtomTypes();
 
     SelectionManager& operator&=(const SelectionManager& sman) {

--- a/src/selection/SelectionSet.cpp
+++ b/src/selection/SelectionSet.cpp
@@ -43,16 +43,17 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
-#ifdef IS_MPI
-#include <mpi.h>
-#endif
+#include "selection/SelectionSet.hpp"
 
 #include <algorithm>
 #include <cassert>
 #include <iterator>
 #include <string>
 
-#include "selection/SelectionSet.hpp"
+#ifdef IS_MPI
+#include <mpi.h>
+#endif
+
 #include "utils/Algorithm.hpp"
 
 namespace OpenMD {

--- a/src/types/AmberImproperTorsionType.hpp
+++ b/src/types/AmberImproperTorsionType.hpp
@@ -88,5 +88,5 @@ namespace OpenMD {
     return os;
   }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_OPLSTORSIONTYPE_HPP

--- a/src/types/BendType.hpp
+++ b/src/types/BendType.hpp
@@ -74,5 +74,5 @@ namespace OpenMD {
     RealType theta0_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_BENDTYPE_HPP

--- a/src/types/BondType.hpp
+++ b/src/types/BondType.hpp
@@ -74,5 +74,5 @@ namespace OpenMD {
     RealType r0; /**equilibrium bond length< */
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_BONDTYPE_HPP

--- a/src/types/CharmmTorsionType.cpp
+++ b/src/types/CharmmTorsionType.cpp
@@ -87,4 +87,4 @@ namespace OpenMD {
     myfile << "The Polynomial contains below terms:" << std::endl;*/
     }
   }
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/types/CharmmTorsionType.hpp
+++ b/src/types/CharmmTorsionType.hpp
@@ -85,5 +85,5 @@ namespace OpenMD {
     CharmmTorsionType(std::vector<CharmmTorsionParameter>& parameters);
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_CHARMMTORSIONTYPE_HPP

--- a/src/types/CosineBendType.hpp
+++ b/src/types/CosineBendType.hpp
@@ -88,5 +88,5 @@ namespace OpenMD {
     RealType c0_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_COSINEBENDTYPE_HPP

--- a/src/types/CosineSeriesBendType.hpp
+++ b/src/types/CosineSeriesBendType.hpp
@@ -88,5 +88,5 @@ namespace OpenMD {
     RealType c2_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_COSINESERIESBENDTYPE_HPP

--- a/src/types/CubicBendType.hpp
+++ b/src/types/CubicBendType.hpp
@@ -98,5 +98,5 @@ namespace OpenMD {
     RealType k0_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_CUBICBENDTYPE_HPP

--- a/src/types/CubicBondType.hpp
+++ b/src/types/CubicBondType.hpp
@@ -98,5 +98,5 @@ namespace OpenMD {
     RealType k0_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_CUBICBONDTYPE_HPP

--- a/src/types/CubicTorsionType.hpp
+++ b/src/types/CubicTorsionType.hpp
@@ -95,5 +95,5 @@ namespace OpenMD {
     RealType k0_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_CUBICTORSIONTYPE_HPP

--- a/src/types/FixedBondType.hpp
+++ b/src/types/FixedBondType.hpp
@@ -73,5 +73,5 @@ namespace OpenMD {
     }
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_FIXEDBONDTYPE_HPP

--- a/src/types/HarmonicBendType.hpp
+++ b/src/types/HarmonicBendType.hpp
@@ -80,5 +80,5 @@ namespace OpenMD {
     RealType k_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_HARMONICBENDTYPE_HPP

--- a/src/types/HarmonicInversionType.hpp
+++ b/src/types/HarmonicInversionType.hpp
@@ -95,5 +95,5 @@ namespace OpenMD {
     return os;
   }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_HARMONICINVERSIONTYPE_HPP

--- a/src/types/HarmonicSineBendType.hpp
+++ b/src/types/HarmonicSineBendType.hpp
@@ -79,5 +79,5 @@ namespace OpenMD {
     RealType k_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_HARMONICSINEBENDTYPE_HPP

--- a/src/types/HarmonicTorsionType.hpp
+++ b/src/types/HarmonicTorsionType.hpp
@@ -109,5 +109,5 @@ namespace OpenMD {
     return os;
   }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_HARMONICTORSIONTYPE_HPP

--- a/src/types/ImproperCosineInversionType.cpp
+++ b/src/types/ImproperCosineInversionType.cpp
@@ -77,4 +77,4 @@ namespace OpenMD {
       this->setPolynomial(finalPolynomial);
     }
   }
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/types/ImproperCosineInversionType.hpp
+++ b/src/types/ImproperCosineInversionType.hpp
@@ -86,5 +86,5 @@ namespace OpenMD {
         std::vector<ImproperCosineInversionParameter>& parameters);
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_IMPROPERCOSINEINVERSIONTYPE_HPP

--- a/src/types/InversionType.hpp
+++ b/src/types/InversionType.hpp
@@ -74,5 +74,5 @@ namespace OpenMD {
     virtual InversionKey getKey()               = 0;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_INVERSIONTYPE_HPP

--- a/src/types/NonBondedInteractionType.hpp
+++ b/src/types/NonBondedInteractionType.hpp
@@ -159,5 +159,5 @@ namespace OpenMD {
     PropertyMap properties_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_NONBONDEDINTERACTIONTYPE_HPP

--- a/src/types/OplsTorsionType.hpp
+++ b/src/types/OplsTorsionType.hpp
@@ -116,5 +116,5 @@ namespace OpenMD {
     return os;
   }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_OPLSTORSIONTYPE_HPP

--- a/src/types/PolynomialBendType.hpp
+++ b/src/types/PolynomialBendType.hpp
@@ -117,5 +117,5 @@ namespace OpenMD {
     }
     return os;
   }
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_POLYNOMIALBENDTYPE_HPP

--- a/src/types/PolynomialBondType.hpp
+++ b/src/types/PolynomialBondType.hpp
@@ -118,5 +118,5 @@ namespace OpenMD {
     return os;
   }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_POLYNOMIALBONDTYPE_HPP

--- a/src/types/PolynomialInversionType.hpp
+++ b/src/types/PolynomialInversionType.hpp
@@ -127,5 +127,5 @@ namespace OpenMD {
      }
   */
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_POLYNOMIALINVERSIONTYPE_HPP

--- a/src/types/PolynomialTorsionType.hpp
+++ b/src/types/PolynomialTorsionType.hpp
@@ -126,5 +126,5 @@ namespace OpenMD {
      return os;
      }*/
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_POLYNOMIALTORSIONTYPE_HPP

--- a/src/types/QuarticBendType.hpp
+++ b/src/types/QuarticBendType.hpp
@@ -103,5 +103,5 @@ namespace OpenMD {
     RealType k1_;
     RealType k0_;
   };
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_QUARTICBENDTYPE_HPP

--- a/src/types/QuarticBondType.hpp
+++ b/src/types/QuarticBondType.hpp
@@ -103,5 +103,5 @@ namespace OpenMD {
     RealType k0_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_QUADRATICBONDTYPE_HPP

--- a/src/types/QuarticTorsionType.hpp
+++ b/src/types/QuarticTorsionType.hpp
@@ -103,5 +103,5 @@ namespace OpenMD {
     RealType k0_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_QUADRATICTORSIONTYPE_HPP

--- a/src/types/TorsionType.hpp
+++ b/src/types/TorsionType.hpp
@@ -66,5 +66,5 @@ namespace OpenMD {
                            RealType& dVdCosPhi) = 0;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_TORSIONTYPE_HPP

--- a/src/types/TrappeTorsionType.hpp
+++ b/src/types/TrappeTorsionType.hpp
@@ -128,5 +128,5 @@ namespace OpenMD {
     return os;
   }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_TRAPPETORSIONTYPE_HPP

--- a/src/types/UreyBradleyBendType.hpp
+++ b/src/types/UreyBradleyBendType.hpp
@@ -82,5 +82,5 @@ namespace OpenMD {
     HarmonicBondType hbt_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // TYPES_UREYBRADLEYBENDTYPE_HPP

--- a/src/utils/LocalIndexManager.hpp
+++ b/src/utils/LocalIndexManager.hpp
@@ -360,5 +360,5 @@ namespace OpenMD {
     IndexListContainer inversionIndexContainer_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // UTILS_LOCALINDEXMANAGER_HPP

--- a/src/utils/OpenMDBitSet.cpp
+++ b/src/utils/OpenMDBitSet.cpp
@@ -43,17 +43,18 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
-#ifdef IS_MPI
-#include <mpi.h>
-#endif
+#include "utils/OpenMDBitSet.hpp"
 
 #include <algorithm>
 #include <cassert>
 #include <iterator>
 #include <string>
 
+#ifdef IS_MPI
+#include <mpi.h>
+#endif
+
 #include "utils/Algorithm.hpp"
-#include "utils/OpenMDBitSet.hpp"
 
 namespace OpenMD {
   int OpenMDBitSet::countBits() {
@@ -110,18 +111,18 @@ namespace OpenMD {
 
     return -1;
   }
-  
-  int OpenMDBitSet::nthOffBit(unsigned long int fromIndex, unsigned long int n) const {
 
+  int OpenMDBitSet::nthOffBit(unsigned long int fromIndex,
+                              unsigned long int n) const {
     std::vector<int> indices;
     for (int i = nextOffBit(fromIndex); i != -1; i = nextOffBit(i + 1)) {
       indices.push_back(i);
     }
-    
+
     if (n <= indices.size()) return indices[n];
     return -1;
   }
-  
+
   int OpenMDBitSet::nextOnBit(int fromIndex) const {
     if (fromIndex <= -1) {
       // in case -1 or other negative number is passed to this function
@@ -137,17 +138,17 @@ namespace OpenMD {
     return -1;
   }
 
-  int OpenMDBitSet::nthOnBit(unsigned long int fromIndex, unsigned long int n) const {
-
+  int OpenMDBitSet::nthOnBit(unsigned long int fromIndex,
+                             unsigned long int n) const {
     std::vector<int> indices;
     for (int i = nextOnBit(fromIndex); i != -1; i = nextOnBit(i + 1)) {
       indices.push_back(i);
     }
-    
+
     if (n <= indices.size()) return indices[n];
     return -1;
   }
-  
+
   void OpenMDBitSet::andOperator(const OpenMDBitSet& bs) {
     assert(size() == bs.size());
 

--- a/src/utils/OpenMDBitSet.hpp
+++ b/src/utils/OpenMDBitSet.hpp
@@ -94,7 +94,7 @@ namespace OpenMD {
     /** Returns the index of the first bit that is set to false that occurs on
      * or after the specified starting index.*/
     int nextOffBit(int fromIndex) const;
-    
+
     /** Returns the index of the n^th bit that is set to false that occurs on
      * or after the specified starting index.*/
     int nthOffBit(unsigned long int fromIndex, unsigned long int n) const;

--- a/src/utils/ProgressBar.cpp
+++ b/src/utils/ProgressBar.cpp
@@ -43,10 +43,6 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
-#ifdef IS_MPI
-#include <mpi.h>
-#endif
-
 #include <cstdlib>
 #include <iostream>
 
@@ -62,6 +58,10 @@
 #include <cstdio>
 
 #include <sys/ioctl.h>
+#endif
+
+#ifdef IS_MPI
+#include <mpi.h>
 #endif
 
 #include "utils/ProgressBar.hpp"

--- a/src/utils/PropertyMap.cpp
+++ b/src/utils/PropertyMap.cpp
@@ -120,4 +120,4 @@ namespace OpenMD {
       return NULL;
   }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/utils/StringTokenizer.cpp
+++ b/src/utils/StringTokenizer.cpp
@@ -246,4 +246,4 @@ namespace OpenMD {
     return result;
   }
 
-}  // end namespace OpenMD
+}  // namespace OpenMD

--- a/src/utils/Trim.hpp
+++ b/src/utils/Trim.hpp
@@ -195,5 +195,5 @@ namespace OpenMD {
    */
   std::string trimCopy(const std::string& input);
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // UTILS_TRIM_HPP

--- a/src/utils/TypeContainer.hpp
+++ b/src/utils/TypeContainer.hpp
@@ -206,6 +206,6 @@ namespace OpenMD {
     MapType data_;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 
 #endif  // UTILS_TYPECONTAINER_HPP

--- a/src/utils/next_combination.hpp
+++ b/src/utils/next_combination.hpp
@@ -154,5 +154,5 @@ namespace OpenMD {
     }
   }  // end next_combination
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif  // UTILS_NEXT_COMBINATION_HPP

--- a/src/utils/simError.cpp
+++ b/src/utils/simError.cpp
@@ -43,9 +43,7 @@
  * [8] Bhattarai, Newman & Gezelter, Phys. Rev. B 99, 094106 (2019).
  */
 
-#ifdef IS_MPI
-#include <mpi.h>
-#endif
+#include "utils/simError.h"
 
 #include <config.h>
 
@@ -53,9 +51,11 @@
 #include <cstdlib>
 #include <cstring>
 
-int nChecks;
+#ifdef IS_MPI
+#include <mpi.h>
+#endif
 
-#include "utils/simError.h"
+int nChecks;
 
 errorStruct painCave;
 

--- a/src/visitors/BaseVisitor.hpp
+++ b/src/visitors/BaseVisitor.hpp
@@ -98,5 +98,5 @@ namespace OpenMD {
     std::string visitorName;
   };
 
-}  // end namespace OpenMD
+}  // namespace OpenMD
 #endif


### PR DESCRIPTION
The major change this pull request introduces is the renaming of `ForceManager` to `ForceModifier`. The reason for this change (or rather, distinction) between the two will be realized when the slow particle flux (SPF) code is added. Basically, a `ForceManager`'s job is to calculate the forces and potentials for each atom in the simulation. In order to derive from `ForceManager`, a class should change this method directly rather than simply add to it. Thus, `ForceModifier`s were added to represent routines that would modify the forces (or potentials) themselves rather than the methods used to calculate them. Some examples include `ThermoIntegrationForceModifier`, `RestraintForceModifier`, `LDForceModifier`, `LangevinHullForceModifier`, and `ZConstraintForceModifier`.  The classes that were previously classified as `Perturbation`s also fit this description and were renamed to `ForceModifier`s.

Currently, there is no additional `ForceManager` but work is in progress on a class to directly modify the force loop calculations, and one can envision Grand Canonical Molecular Dynamics (GCMD) requiring a non-standard force loop as well.

Additionally some formatting changes were applied to various files throughout the codebase. Notably, the order of `#include` statements were updated to account for the `# IS_MPI` macros, and trailing namespace comments were all changed to `// namespace <namespace>` from `// end namespace <namespace>`.